### PR TITLE
Add missing required "Client-Id" header to Twitch Provider docs

### DIFF
--- a/docs/pages/providers/twitch.md
+++ b/docs/pages/providers/twitch.md
@@ -29,6 +29,7 @@ Use the [`/users` endpoint](https://dev.twitch.tv/docs/api/reference/#get-users)
 const response = await fetch("https://api.twitch.tv/helix/users", {
 	headers: {
 		Authorization: `Bearer ${accessToken}`
+		'Client-Id': clientId
 	}
 });
 const user = await response.json();


### PR DESCRIPTION
The `https://api.twitch.tv/helix/users` endpoint requires you to pass your Twitch OAuth Application's "Client-Id as a header.

Not supplying the "Client-Id" header will result in this error:
```
{ error: 'Unauthorized', status: 401, message: 'Client ID is missing' }
```

This PR adds this header to the documentation