### PR TITLE
Okta provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ const tokens = await github.validateAuthorizationCode(code);
 - LinkedIn
 - Microsoft Entra ID
 - Notion
+- Okta
 - Reddit
 - Salesforce
 - Spotify

--- a/docs/pages/providers/okta.md
+++ b/docs/pages/providers/okta.md
@@ -1,0 +1,35 @@
+---
+title: "Okta"
+---
+
+# Okta
+
+Implements OpenID Connect.
+
+For usage, see [OAuth 2.0 provider with PKCE](/guides/oauth2-pkce).
+
+**Note:** This provider implements a subset of Okta's full OAuth2 implementation. Specifically for applications of the "Web Application" type when using the OIDC sign-in method.
+
+It is also recommended to toggle "Require PKCE as additional verification" under client credentials after creating your application in the Okta admin dashboard, as the implementation forces you to use PKCE anyway.
+
+If you want to utilise the refresh functionality of Arctic you need to toggle the "Refresh Token" option for "Client acting on behalf of a user". You can find this option under "Grant type" in the general settings for the application.
+
+```ts
+import { Okta } from "arctic";
+
+const okta = new Okta(oktaDomain, clientId, clientSecret, redirectURI);
+```
+
+```ts
+const url: URL = await okta.createAuthorizationURL(state, codeVerifier, {
+	// optional
+	scopes // "openid" always included
+});
+
+const tokens: OktaTokens = await okta.validateAuthorizationCode(code, codeVerifier);
+
+const tokens: OktaTokens = await okta.refreshAccessToken(refreshToken, {
+	// optional
+	scopes // "openid" and "offline_access" always included
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { Tumblr } from "./providers/tumblr.js";
 export { Twitch } from "./providers/twitch.js";
 export { Twitter } from "./providers/twitter.js";
 export { Yahoo } from "./providers/yahoo.js";
+export { Okta } from "./providers/okta.js";
 
 export type { AppleCredentials, AppleRefreshedTokens, AppleTokens } from "./providers/apple.js";
 export type { AtlassianTokens } from "./providers/atlassian.js";
@@ -50,6 +51,7 @@ export type { TumblrTokens } from "./providers/tumblr.js";
 export type { TwitchTokens } from "./providers/twitch.js";
 export type { TwitterTokens } from "./providers/twitter.js";
 export type { YahooTokens } from "./providers/yahoo.js";
+export type { OktaTokens } from "./providers/okta.js";
 
 export { generateCodeVerifier, generateState, OAuth2RequestError } from "oslo/oauth2";
 

--- a/src/providers/okta.ts
+++ b/src/providers/okta.ts
@@ -49,10 +49,17 @@ export class Okta implements OAuth2ProviderWithPKCE {
 		return tokens;
 	}
 
-	public async refreshAccessToken(refreshToken: string): Promise<OktaTokens> {
+	public async refreshAccessToken(
+		refreshToken: string,
+		options?: {
+			scopes?: string[];
+		}
+	): Promise<OktaTokens> {
 		const result = await this.client.refreshAccessToken<TokenResponseBody>(refreshToken, {
 			authenticateWith: "request_body",
-			credentials: this.clientSecret
+			credentials: this.clientSecret,
+			// To get a refresh token in the first place the "offline_access" scope is needed, thus we can confidently add that here
+			scopes: [...(options?.scopes ?? []), "openid", "offline_access"]
 		});
 
 		const tokens: OktaTokens = {

--- a/src/providers/okta.ts
+++ b/src/providers/okta.ts
@@ -1,0 +1,86 @@
+import { OAuth2Client } from "oslo/oauth2";
+import type { OAuth2ProviderWithPKCE } from "../index.js";
+import { TimeSpan, createDate } from "oslo";
+
+export class Okta implements OAuth2ProviderWithPKCE {
+	private client: OAuth2Client;
+	private clientSecret: string;
+
+	constructor(oktaDomain: string, clientId: string, clientSecret: string, redirectURI: string) {
+		const authorizeEndpoint = `https://${oktaDomain}/oauth2/v1/authorize`;
+		const tokenEndpoint = `https://${oktaDomain}/oauth2/v1/token`;
+		this.client = new OAuth2Client(clientId, authorizeEndpoint, tokenEndpoint, {
+			redirectURI
+		});
+		this.clientSecret = clientSecret;
+	}
+
+	public async createAuthorizationURL(
+		state: string,
+		codeVerifier: string,
+		options?: {
+			scopes?: string[];
+		}
+	): Promise<URL> {
+		const url = await this.client.createAuthorizationURL({
+			codeVerifier,
+			scopes: [...(options?.scopes ?? []), "openid"]
+		});
+		url.searchParams.set("state", state);
+
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string, codeVerifier: string): Promise<OktaTokens> {
+		const result = await this.client.validateAuthorizationCode<TokenResponseBody>(code, {
+			authenticateWith: "request_body",
+			codeVerifier,
+			credentials: this.clientSecret
+		});
+
+		const tokens: OktaTokens = {
+			accessToken: result.access_token,
+			refreshToken: result.refresh_token ?? null,
+			accessTokenExpiresAt: createDate(new TimeSpan(result.expires_in, "s")),
+			idToken: result.id_token,
+			deviceSecret: result.device_secret ?? null
+		};
+
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OktaTokens> {
+		const result = await this.client.refreshAccessToken<TokenResponseBody>(refreshToken, {
+			authenticateWith: "request_body",
+			credentials: this.clientSecret
+		});
+
+		const tokens: OktaTokens = {
+			accessToken: result.access_token,
+			refreshToken: result.refresh_token ?? null,
+			accessTokenExpiresAt: createDate(new TimeSpan(result.expires_in, "s")),
+			idToken: result.id_token,
+			deviceSecret: result.device_secret ?? null
+		};
+
+		return tokens;
+	}
+}
+
+interface TokenResponseBody {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	scope: string;
+	refresh_token?: string;
+	id_token: string;
+	device_secret?: string;
+}
+
+export interface OktaTokens {
+	idToken: string;
+	accessToken: string;
+	accessTokenExpiresAt: Date;
+	refreshToken: string | null;
+	deviceSecret: string | null;
+}


### PR DESCRIPTION
This implents Okta's OAuth and OIDC provider.

**Important!** This relies on an Oslo PR https://github.com/pilcrowOnPaper/oslo/pull/19, as this relies on the implementation of scopes when refreshing a token. See: https://github.com/pilcrowOnPaper/oslo/issues/18 for details.

Resolves #38 