### PR TITLE
Discord oauth scope "identity" -> "identify"

### DIFF
--- a/docs/pages/providers/discord.md
+++ b/docs/pages/providers/discord.md
@@ -27,7 +27,7 @@ Add the `identity` scope and use the [`/users/@me` endpoint`]().
 
 ```ts
 const url = await discord.createAuthorizationURL(state, {
-	scopes: ["identity"]
+	scopes: ["identify"]
 });
 ```
 


### PR DESCRIPTION
both because I am using it and per the docs:
https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes