### PR TITLE
Fix dropbox docs + token verification request

### DIFF
--- a/.changesets/7hiye.patch.md
+++ b/.changesets/7hiye.patch.md
@@ -1,0 +1,1 @@
+Fix: Use request body for sending credentials in Dropbox provider

--- a/docs/pages/providers/dropbox.md
+++ b/docs/pages/providers/dropbox.md
@@ -6,7 +6,7 @@ title: "Dropbox"
 
 Implements OpenID Connect.
 
-For usage, see [OAuth 2.0 provider with PKCE](/guides/oauth2-pkce).
+For usage, see [OAuth 2.0 provider](/guides/oauth2).
 
 ```ts
 import { Dropbox } from "arctic";

--- a/src/providers/dropbox.ts
+++ b/src/providers/dropbox.ts
@@ -34,6 +34,7 @@ export class Dropbox implements OAuth2Provider {
 		const result = await this.client.validateAuthorizationCode<AuthorizationCodeResponseBody>(
 			code,
 			{
+				authenticateWith: "request_body",
 				credentials: this.clientSecret
 			}
 		);
@@ -48,6 +49,7 @@ export class Dropbox implements OAuth2Provider {
 
 	public async refreshAccessToken(refreshToken: string): Promise<DropboxRefreshedTokens> {
 		const result = await this.client.refreshAccessToken<RefreshTokenResponseBody>(refreshToken, {
+			authenticateWith: "request_body",
 			credentials: this.clientSecret
 		});
 		const tokens: DropboxRefreshedTokens = {


### PR DESCRIPTION
- The docs need to reference to oauth2 w/e PKCE because the provider currently not setup for it
- The dropbox provider now uses the request body for the token verification request