### PR TITLE
Auri: Release request (v1.1.5)

### DIFF
--- a/.changesets/176co.patch.md
+++ b/.changesets/176co.patch.md
@@ -1,1 +1,0 @@
-Fix: Fix wrong refresh token expiration date in Keycloak provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # arctic
 
+## 1.1.5
+
+### Patch changes
+
+- Fix: Fix wrong refresh token expiration date in Keycloak provider ([#65](https://github.com/pilcrowOnPaper/arctic/pull/65))
+
 ## 1.1.4
 
 ### Patch changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arctic",
 	"type": "module",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "OAuth 2.0 clients for popular providers",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Patch changes
- Fix: Fix wrong refresh token expiration date in Keycloak provider ([#65](https://github.com/pilcrowOnPaper/arctic/pull/65))
