### PR TITLE
Fix: Export GitLab provider

### DIFF
--- a/.changesets/b03st.patch.md
+++ b/.changesets/b03st.patch.md
@@ -1,0 +1,1 @@
+Fix: Export GitLab provider

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Dropbox } from "./providers/dropbox.js";
 export { Facebook } from "./providers/facebook.js";
 export { Figma } from "./providers/figma.js";
 export { GitHub } from "./providers/github.js";
+export { GitLab } from "./providers/gitlab.js";
 export { Google } from "./providers/google.js";
 export { Kakao } from "./providers/kakao.js";
 export { Keycloak } from "./providers/keycloak.js";


### PR DESCRIPTION
This PR is made to solve issue #72 regarding the unexported GitLab provider

Changes made:
 - [x] Export GitLab provider to `src/index.ts`