### PR TITLE
Auri: Release request (v1.2.1)

### DIFF
--- a/.changesets/ocm8z.patch.md
+++ b/.changesets/ocm8z.patch.md
@@ -1,1 +1,0 @@
-Move `auri` to dev dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # arctic
 
+## 1.2.1
+
+### Patch changes
+
+- Move `auri` to dev dependencies. ([#75](https://github.com/pilcrowOnPaper/arctic/pull/75))
+
 ## 1.2.0
 
 ### Minor changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arctic",
 	"type": "module",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "OAuth 2.0 clients for popular providers",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Patch changes
- Move `auri` to dev dependencies. ([#75](https://github.com/pilcrowOnPaper/arctic/pull/75))
