### PR TITLE
[DOCS] Fixes a wrong scope for the GitHub API

### DIFF
--- a/docs/pages/providers/github.md
+++ b/docs/pages/providers/github.md
@@ -42,7 +42,7 @@ Add the `email` scope and use the [`/user/emails` endpoint](https://docs.github.
 
 ```ts
 const url = await github.createAuthorizationURL(state, {
-	scopes: ["email"]
+	scopes: ["user:email"]
 });
 ```
 


### PR DESCRIPTION
Hello,
the scope for receiving the emails from the GitHub API is wrong. This PR fixes the scope.
You can see the right scope [here](https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user).
Thank you!
Kind regards
Sharknoon