### PR TITLE
Remove nonce from Google auth URL parameters

### DIFF
--- a/docs/pages/providers/google.md
+++ b/docs/pages/providers/google.md
@@ -4,7 +4,7 @@ title: "Google"
 
 # Google
 
-Implements OpenID Connect. By default, `nonce` is set to `_`.
+Implements OpenID Connect.
 
 For usage, see [OAuth 2.0 provider with PKCE](/guides/oauth2-pkce).
 

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -30,7 +30,6 @@ export class Google implements OAuth2ProviderWithPKCE {
 			codeVerifier,
 			scopes: [...scopes, "openid"]
 		});
-		url.searchParams.set("nonce", "_");
 		return url;
 	}
 

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -25,12 +25,11 @@ export class Google implements OAuth2ProviderWithPKCE {
 		}
 	): Promise<URL> {
 		const scopes = options?.scopes ?? [];
-		const url = await this.client.createAuthorizationURL({
+		return await this.client.createAuthorizationURL({
 			state,
 			codeVerifier,
 			scopes: [...scopes, "openid"]
 		});
-		return url;
 	}
 
 	public async validateAuthorizationCode(


### PR DESCRIPTION
This does not seem to be necessary according to the docs for native and web apps:

- [Using OAuth 2.0 for Web Server Applications](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient)
- [OAuth 2.0 for Mobile & Desktop Apps](https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server)

The nonce parameter is not required by Google and does not seem to be used by arctic anyway.

There is a mention about nonce in [these docs](https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server), but I guess it doesn't add any further protection when code verifier and state are used (and nonce set to a fixed value instead of a random string).