### PR TITLE
Add GitHub Enterprise support to GitHub Provider

### DIFF
--- a/.changesets/2gldm.minor.md
+++ b/.changesets/2gldm.minor.md
@@ -1,0 +1,1 @@
+Feat: Add Enterprise support to `GitHub` provider.

--- a/docs/pages/providers/github.md
+++ b/docs/pages/providers/github.md
@@ -11,6 +11,8 @@ import { GitHub } from "arctic";
 
 const github = new GitHub(clientId, clientSecret, {
 	// optional
+	authorizeEndpoint, // can be overridden for usage with GitHub Enterprise
+	tokenEndpoint, // can be overridden for usage with GitHub Enterprise
 	redirectURI // required when multiple redirect URIs are defined
 });
 ```
@@ -35,6 +37,8 @@ const response = await fetch("https://api.github.com/user", {
 });
 const user = await response.json();
 ```
+
+Usage with an GitHub Enterprise instance would be as easy as changing the API-Endpoint URL to `http(s)://HOSTNAME/api/v3`.
 
 ## Get email
 

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -2,8 +2,8 @@ import { OAuth2Client } from "oslo/oauth2";
 
 import type { OAuth2Provider } from "../index.js";
 
-const authorizeEndpoint = "https://github.com/login/oauth/authorize";
-const tokenEndpoint = "https://github.com/login/oauth/access_token";
+const defaultAuthorizeEndpoint = "https://github.com/login/oauth/authorize";
+const defaultTokenEndpoint = "https://github.com/login/oauth/access_token";
 
 export class GitHub implements OAuth2Provider {
 	private client: OAuth2Client;
@@ -13,9 +13,16 @@ export class GitHub implements OAuth2Provider {
 		clientId: string,
 		clientSecret: string,
 		options?: {
+			authorizeEndpoint?: string;
+			tokenEndpoint?: string;
 			redirectURI?: string;
 		}
 	) {
+		// Set the authorize and token endpoints to the default GitHub endpoints if not provided
+		// Enables usage with GitHub Enterprise instances
+		const authorizeEndpoint = options?.authorizeEndpoint ?? defaultAuthorizeEndpoint;
+		const tokenEndpoint = options?.tokenEndpoint ?? defaultTokenEndpoint;
+
 		this.client = new OAuth2Client(clientId, authorizeEndpoint, tokenEndpoint, {
 			redirectURI: options?.redirectURI
 		});


### PR DESCRIPTION
This PR adds support for customizing the `authorizeEndpoint` as well as the `tokenEndpoint` of the `GitHub` provider as well as adds the necessary documentation for it.

Usage example of the features introduced:

```ts
const github = new GitHub(clientId, clientSecret, {
	authorizeEndpoint: "https://github.enterprise.com/login/oauth/authorize",
	tokenEndpoint: "https://github.enterprise.com/login/oauth/access_token"
});
```