### PR TITLE
fix(docs): typo in atlassian validateAuthorizationCode function call

### DIFF
--- a/docs/pages/providers/atlassian.md
+++ b/docs/pages/providers/atlassian.md
@@ -32,7 +32,7 @@ const url = await atlassian.createAuthorizationURL(state, {
 ```
 
 ```ts
-const tokens = await apple.validateAuthorizationCode(code);
+const tokens = await atlassian.validateAuthorizationCode(code);
 const response = await fetch("https://api.atlassian.com/me", {
 	headers: {
 		Authorization: `Bearer ${tokens.accessToken}`


### PR DESCRIPTION
Corrected a typo in the function call from apple.validateAuthorizationCode(code) to atlassian.validateAuthorizationCode(code)