### PR TITLE
docs: Remove extra ticks that break some formatting

### DIFF
--- a/docs/pages/providers/coinbase.md
+++ b/docs/pages/providers/coinbase.md
@@ -26,7 +26,7 @@ const tokens: CoinbaseTokens = await coinbase.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Use the [`/user` endpoint`](https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/api-users#show-current-user).
+Use the [`/user` endpoint](https://docs.cloud.coinbase.com/sign-in-with-coinbase/docs/api-users#show-current-user).
 
 ```ts
 const tokens = await coinbase.validateAuthorizationCode(code);

--- a/docs/pages/providers/discord.md
+++ b/docs/pages/providers/discord.md
@@ -23,7 +23,7 @@ const tokens: DiscordTokens = await discord.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Add the `identify` scope and use the [`/users/@me` endpoint`](https://discord.com/developers/docs/resources/user#get-current-user).
+Add the `identify` scope and use the [`/users/@me` endpoint](https://discord.com/developers/docs/resources/user#get-current-user).
 
 ```ts
 const url = await discord.createAuthorizationURL(state, {

--- a/docs/pages/providers/osu.md
+++ b/docs/pages/providers/osu.md
@@ -26,7 +26,7 @@ const tokens: OsuTokens = await osu.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Use the [`/me` endpoint`](https://osu.ppy.sh/docs/index.html#get-own-data).
+Use the [`/me` endpoint](https://osu.ppy.sh/docs/index.html#get-own-data).
 
 ```ts
 const url = await osu.createAuthorizationURL(state, {

--- a/docs/pages/providers/patreon.md
+++ b/docs/pages/providers/patreon.md
@@ -23,7 +23,7 @@ const tokens: PatreonTokens = await patreon.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Add the `identity` scope and use the [`/api/oauth2/v2/identity` endpoint`](https://docs.patreon.com/#get-api-oauth2-v2-identity). Optionally add the `identity[email]` scope to get user email.
+Add the `identity` scope and use the [`/api/oauth2/v2/identity` endpoint](https://docs.patreon.com/#get-api-oauth2-v2-identity). Optionally add the `identity[email]` scope to get user email.
 
 ```ts
 const url = await patreon.createAuthorizationURL(state, {

--- a/docs/pages/providers/strava.md
+++ b/docs/pages/providers/strava.md
@@ -23,7 +23,7 @@ const tokens: StravaTokens = await strava.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Add the `read` scope and use the [`/athlete` endpoint`](https://developers.strava.com/docs/reference/#api-Athletes-getLoggedInAthlete). Alternatively, use the `read_all` scope to get all private data.
+Add the `read` scope and use the [`/athlete` endpoint](https://developers.strava.com/docs/reference/#api-Athletes-getLoggedInAthlete). Alternatively, use the `read_all` scope to get all private data.
 
 ```ts
 const url = await strava.createAuthorizationURL(state, {

--- a/docs/pages/providers/vk.md
+++ b/docs/pages/providers/vk.md
@@ -22,7 +22,7 @@ const tokens: VKTokens = await vk.validateAuthorizationCode(code);
 
 ## Get user profile
 
-Use the [`users.get` endpoint`](https://dev.vk.com/en/method/users.get).
+Use the [`users.get` endpoint](https://dev.vk.com/en/method/users.get).
 
 ```ts
 const tokens = await vk.validateAuthorizationCode(code);

--- a/docs/pages/providers/zoom.md
+++ b/docs/pages/providers/zoom.md
@@ -25,7 +25,7 @@ const tokens: ZoomTokens = await zoom.refreshAccessToken(refreshToken);
 
 ## Get user profile
 
-Add the `user:read` scope and use the [`/users/me` endpoint`](https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/user).
+Add the `user:read` scope and use the [`/users/me` endpoint](https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/user).
 
 ```ts
 const url = await zoom.createAuthorizationURL(state, {


### PR DESCRIPTION
There are a couple of provider doc pages which have broken MD which includes an extra backtick `` ` `` which breaks the link formatting.

Strange ones:
- [Coinbase](https://arctic.js.org/providers/coinbase)
- [Discord](https://arctic.js.org/providers/discord)
- [osu!](https://arctic.js.org/providers/osu)
- [VK](https://arctic.js.org/providers/vk)
- [Zoom](https://arctic.js.org/providers/zoom)

Broken ones:
- [Patreon](https://arctic.js.org/providers/patreon)
- [Strava](https://arctic.js.org/providers/strava)