### PR TITLE
	modified:   src/providers/linkedin.ts

### DIFF
--- a/.changesets/3thlw.minor.md
+++ b/.changesets/3thlw.minor.md
@@ -1,1 +1,0 @@
-Add Intuit provider.

--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,0 +1,2 @@
+Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`
+Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens

--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,1 +1,1 @@
-Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`   
+Feat: Add `idToken` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`   

--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,2 +1,2 @@
-Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`
+Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)` 
 Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens

--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,2 +1,2 @@
-Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)` 
+Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`   
 Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens

--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,2 +1,1 @@
 Feat: Add `id_token` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`   
-Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens

--- a/.changesets/dj9ch.patch.md
+++ b/.changesets/dj9ch.patch.md
@@ -1,1 +1,1 @@
-Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens
+Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)`

--- a/.changesets/dj9ch.patch.md
+++ b/.changesets/dj9ch.patch.md
@@ -1,0 +1,1 @@
+Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` because `refreshToken` is available only if your application is authorized for programmatic refresh tokens

--- a/src/providers/linkedin.ts
+++ b/src/providers/linkedin.ts
@@ -31,25 +31,31 @@ export class LinkedIn implements OAuth2Provider {
 	}
 
 	public async validateAuthorizationCode(code: string): Promise<LinkedInTokens> {
-		const result = await this.client.validateAuthorizationCode<TokenResponseBody>(code, {
-			authenticateWith: "request_body",
-			credentials: this.clientSecret
-		});
+		const result = await this.client.validateAuthorizationCode<AuthorizationCodeResponseBody>(
+			code,
+			{
+				authenticateWith: "request_body",
+				credentials: this.clientSecret
+			}
+		);
 		const tokens: LinkedInTokens = {
+			idToken: result.id_token,
 			accessToken: result.access_token,
 			accessTokenExpiresAt: createDate(new TimeSpan(result.expires_in, "s")),
-			refreshToken: result.refresh_token,
-			refreshTokenExpiresAt: createDate(new TimeSpan(result.refresh_token_expires_in, "s"))
+			refreshToken: result.refresh_token ?? null,
+			refreshTokenExpiresAt: result.refresh_token_expires_in
+				? createDate(new TimeSpan(result.refresh_token_expires_in, "s"))
+				: null
 		};
 		return tokens;
 	}
 
-	public async refreshAccessToken(accessToken: string): Promise<LinkedInTokens> {
-		const result = await this.client.refreshAccessToken<TokenResponseBody>(accessToken, {
+	public async refreshAccessToken(accessToken: string): Promise<LinkedInRefreshedTokens> {
+		const result = await this.client.refreshAccessToken<RefreshTokenResponseBody>(accessToken, {
 			authenticateWith: "request_body",
 			credentials: this.clientSecret
 		});
-		const tokens: LinkedInTokens = {
+		const tokens: LinkedInRefreshedTokens = {
 			accessToken: result.access_token,
 			accessTokenExpiresAt: createDate(new TimeSpan(result.expires_in, "s")),
 			refreshToken: result.refresh_token,
@@ -59,7 +65,15 @@ export class LinkedIn implements OAuth2Provider {
 	}
 }
 
-interface TokenResponseBody {
+interface AuthorizationCodeResponseBody {
+	id_token: string;
+	access_token: string;
+	expires_in: number;
+	refresh_token?: string; // available only if your application is authorized for programmatic refresh tokens
+	refresh_token_expires_in?: number;
+}
+
+interface RefreshTokenResponseBody {
 	access_token: string;
 	expires_in: number;
 	refresh_token: string;
@@ -67,6 +81,14 @@ interface TokenResponseBody {
 }
 
 export interface LinkedInTokens {
+	idToken: string;
+	accessToken: string;
+	accessTokenExpiresAt: Date;
+	refreshToken: string | null;
+	refreshTokenExpiresAt: Date | null;
+}
+
+export interface LinkedInRefreshedTokens {
 	accessToken: string;
 	accessTokenExpiresAt: Date;
 	refreshToken: string;


### PR DESCRIPTION
The id_token was missed from validateAuthorizationCode()
The actual fetch response is like:
```
{
  access_token: 'xxxxxxxxx',
  expires_in: 5183999,
  scope: 'email,openid,profile',
  token_type: 'Bearer',
  id_token: 'xxxxxxxxx'
}
```

The refresh token is available only if your application is authorized for programmatic refresh tokens according to:
https://learn.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens
