### PR TITLE
Auri: Release request (v1.6.2)

### DIFF
--- a/.changesets/k05u0.patch.md
+++ b/.changesets/k05u0.patch.md
@@ -1,1 +1,0 @@
-Use HTTP basic auth for sending client credentials if supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # arctic
 
+## 1.6.2
+
+### Patch changes
+
+- Use HTTP basic auth for sending client credentials if supported ([#113](https://github.com/pilcrowOnPaper/arctic/pull/113))
+
 ## 1.6.1
 
 ### Patch changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arctic",
 	"type": "module",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"description": "OAuth 2.0 clients for popular providers",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Patch changes
- Use HTTP basic auth for sending client credentials if supported ([#113](https://github.com/pilcrowOnPaper/arctic/pull/113))
