### PR TITLE
Auri: Release request (v1.8.0)

### DIFF
--- a/.changesets/a6vql.minor.md
+++ b/.changesets/a6vql.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `idToken` to the return value of LinkedIn's `validateAuthorizationCode(code: string)`   

--- a/.changesets/dj9ch.patch.md
+++ b/.changesets/dj9ch.patch.md
@@ -1,1 +1,0 @@
-Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)`

--- a/.changesets/tb2aa.minor.md
+++ b/.changesets/tb2aa.minor.md
@@ -1,1 +1,0 @@
-Feat: Add Tiltify provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # arctic
 
+## 1.8.0
+
+### Minor changes
+
+- Feat: Add `idToken` to the return value of LinkedIn's `validateAuthorizationCode(code: string)` ([#105](https://github.com/pilcrowOnPaper/arctic/pull/105))
+- Feat: Add Tiltify provider. ([#118](https://github.com/pilcrowOnPaper/arctic/pull/118))
+
+### Patch changes
+
+- Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` ([#105](https://github.com/pilcrowOnPaper/arctic/pull/105))
+
 ## 1.7.0
 
 ### Minor changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arctic",
 	"type": "module",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "OAuth 2.0 clients for popular providers",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Minor changes
- Feat: Add `idToken` to the return value of LinkedIn's `validateAuthorizationCode(code: string)` ([#105](https://github.com/pilcrowOnPaper/arctic/pull/105))
- Feat: Add Tiltify provider. ([#118](https://github.com/pilcrowOnPaper/arctic/pull/118))
## Patch changes
- Fix: Make `refreshToken` optional for the return value of LinkedIn's `validateAuthorizationCode(code: string)` ([#105](https://github.com/pilcrowOnPaper/arctic/pull/105))
