### PR TITLE
feat: type discord scopes

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -20,7 +20,7 @@ export class Discord implements OAuth2Provider {
 	public async createAuthorizationURL(
 		state: string,
 		options?: {
-			scopes?: string[];
+			scopes?: DiscordScope[];
 		}
 	): Promise<URL> {
 		return await this.client.createAuthorizationURL({
@@ -65,3 +65,33 @@ export interface DiscordTokens {
 	refreshToken: string;
 	accessTokenExpiresAt: Date;
 }
+
+type DiscordScope =
+	| "activities.read"
+	| "activities.write"
+	| "applications.builds.read"
+	| "applications.builds.upload"
+	| "applications.commands"
+	| "applications.commands.update"
+	| "applications.commands.permissions.update"
+	| "applications.entitlements"
+	| "applications.store.update"
+	| "bot"
+	| "connections"
+	| "dm_channels.read"
+	| "email"
+	| "gdm.join"
+	| "guilds"
+	| "guilds.join"
+	| "guilds.members.read"
+	| "identify"
+	| "messages.read"
+	| "relationships.read"
+	| "role_connections.write"
+	| "rpc"
+	| "rpc.activities.write"
+	| "rpc.notifications.read"
+	| "rpc.voice.read"
+	| "rpc.voice.write"
+	| "voice"
+	| "webhook.incoming";


### PR DESCRIPTION
This PR aims to type Discord OAuth2 scopes to provide better information for the lib user. 

This way, the lib user will know what scopes are valid or not.