### PR TITLE
Fix url construction in Facebook docs

### DIFF
--- a/docs/pages/providers/facebook.md
+++ b/docs/pages/providers/facebook.md
@@ -27,7 +27,7 @@ Use the `/me` endpoint. See [user fields](https://developers.facebook.com/docs/g
 ```ts
 const tokens = await facebook.validateAuthorizationCode(code);
 
-const url = new Request("https://graph.facebook.com/me");
+const url = new URL("https://graph.facebook.com/me");
 url.searchParams.set("access_token", tokens.accessToken);
 url.searchParams.set("fields", ["id", "name", "picture", "email"].join(","));
 const response = await fetch(url);


### PR DESCRIPTION
Hello, this is a small fix to the Facebook docs in the url construction to get the profile info.