### PR TITLE
add responce_type paramer for line

### DIFF
--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -19,6 +19,7 @@ export class Line {
 
 	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
 		const url = new URL(authorizationEndpoint);
+		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("state", state);
 		url.searchParams.set("scope", scopes.join(" "));


### PR DESCRIPTION
Added the missing response_type parameter to fix the UNSUPPORTED_RESPONSE_TYPE error:

`url.searchParams.set("response_type", "code");`