### PR TITLE
Fixed small link typo in docs

### DIFF
--- a/docs/pages/guides/migrate-v2.md
+++ b/docs/pages/guides/migrate-v2.md
@@ -80,7 +80,7 @@ const url = google.createAuthorizationURL(state, codeVerifier, scopes);
 The initialization parameters have changed for a few providers. See each provider's guide for details.
 
 - [Apple](/providers/apple)
-- [Github](/proviGders/github)
+- [Github](/providers/github)
 - [GitLab](/providers/gitlab)
 - [Microsoft Entra ID](/providers/microsoft-entra-id)
 - [MyAnimeList](/providers/myanimelist)


### PR DESCRIPTION
`/proviGders/github` -> `/providers/github`