### PR TITLE
Add Naver provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Arctic does not strictly follow semantic versioning. While we aim to only introd
 - LinkedIn
 - Microsoft Entra ID
 - MyAnimeList
+- Naver
 - Notion
 - Okta
 - osu!

--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -44,6 +44,7 @@
 				["LinkedIn", "/providers/linkedin"],
 				["Microsoft Entra ID", "/providers/microsoft-entra-id"],
 				["MyAnimeList", "/providers/myanimelist"],
+				["Naver", "/providers/naver"],
 				["Notion", "/providers/notion"],
 				["Okta", "/providers/okta"],
 				["osu!", "/providers/osu"],

--- a/docs/pages/providers/naver.md
+++ b/docs/pages/providers/naver.md
@@ -19,10 +19,7 @@ const naver = new Naver(clientId, clientSecret, redirectURI);
 ## Create authorization URL
 
 ```ts
-import { generateState } from "arctic";
-
-const state = generateState();
-const url = naver.createAuthorizationURL(state);
+const url = naver.createAuthorizationURL();
 ```
 
 ## Validate authorization code

--- a/docs/pages/providers/naver.md
+++ b/docs/pages/providers/naver.md
@@ -24,7 +24,7 @@ const url = naver.createAuthorizationURL();
 
 ## Validate authorization code
 
-`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Naver returns an access token, its expiration, and a refresh token.
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Naver returns an access token and a refresh token.
 
 ```ts
 import { OAuth2RequestError, ArcticFetchError } from "arctic";
@@ -33,7 +33,6 @@ try {
 	const tokens = await naver.validateAuthorizationCode(code);
 
 	const accessToken = tokens.accessToken();
-	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
 	const refreshToken = tokens.refreshToken();
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {
@@ -50,9 +49,19 @@ try {
 }
 ```
 
+It also returns the access token expiration, but does so in a non-RFC compliant manner. This is a known issue with Naver.
+
+```ts
+const tokens = await bungie.validateAuthorizationCode(code);
+// Should be returned as a number per RFC 6749, but returns it as a string.
+if ("expires_in" in tokens.data && typeof tokens.data.expires_in === "string") {
+	const accessTokenExpiresIn = Number(tokens.data.expires_in);
+}
+```
+
 ## Refresh access tokens
 
-Use `refreshAccessToken()` to get a new access token using a refresh token. Naver returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+Use `refreshAccessToken()` to get a new access token using a refresh token. Naver returns the same values as during the authorization code validation, including the access token expiration which needs to be manually parsed out. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
 
 ```ts
 import { OAuth2RequestError, ArcticFetchError } from "arctic";
@@ -60,7 +69,6 @@ import { OAuth2RequestError, ArcticFetchError } from "arctic";
 try {
 	const tokens = await naver.refreshAccessToken(refreshToken);
 	const accessToken = tokens.accessToken();
-	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
 	const refreshToken = tokens.refreshToken();
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/providers/naver.md
+++ b/docs/pages/providers/naver.md
@@ -1,0 +1,90 @@
+---
+title: "Naver"
+---
+
+# Naver
+
+OAuth 2.0 provider for Naver.
+
+Also see the [OAuth 2.0](/guides/oauth2) guide.
+
+## Initialization
+
+```ts
+import { Naver } from "arctic";
+
+const naver = new Naver(clientId, clientSecret, redirectURI);
+```
+
+## Create authorization URL
+
+```ts
+import { generateState } from "arctic";
+
+const state = generateState();
+const url = naver.createAuthorizationURL(state);
+```
+
+## Validate authorization code
+
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Naver returns an access token, its expiration, and a refresh token.
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+try {
+	const tokens = await naver.validateAuthorizationCode(code);
+
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+	const refreshToken = tokens.refreshToken();
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+		const code = e.code;
+		// ...
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+		const cause = e.cause;
+		// ...
+	}
+	// Parse error
+}
+```
+
+## Refresh access tokens
+
+Use `refreshAccessToken()` to get a new access token using a refresh token. Naver returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+try {
+	const tokens = await naver.refreshAccessToken(refreshToken);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+	const refreshToken = tokens.refreshToken();
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+	}
+	// Parse error
+}
+```
+
+## Get user profile
+
+Use the [`/v1/nid/me` endpoint](https://developers.naver.com/docs/login/devguide/devguide.md#3-4-5-접근-토큰을-이용하여-프로필-api-호출하기).
+
+```ts
+const response = await fetch("https://openapi.naver.com/v1/nid/me", {
+	headers: {
+		Authorization: `Bearer ${accessToken}`
+	}
+});
+const user = await response.json();
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { Linear } from "./providers/linear.js";
 export { LinkedIn } from "./providers/linkedin.js";
 export { MicrosoftEntraId } from "./providers/microsoft-entra-id.js";
 export { MyAnimeList } from "./providers/myanimelist.js";
+export { Naver } from "./providers/naver.js";
 export { Notion } from "./providers/notion.js";
 export { Okta } from "./providers/okta.js";
 export { Osu } from "./providers/osu.js";

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -23,12 +23,8 @@ export class OAuth2Tokens {
 	}
 
 	public accessTokenExpiresInSeconds(): number {
-		if ("expires_in" in this.data) {
-			const expires_in = parseInt(`${this.data.expires_in}`);
-
-			if (typeof expires_in === "number" && !Number.isNaN(expires_in)) {
-				return expires_in;
-			}
+		if ("expires_in" in this.data && typeof this.data.expires_in === "number") {
+			return this.data.expires_in;
 		}
 		throw new Error("Missing or invalid 'expires_in' field");
 	}

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -23,8 +23,12 @@ export class OAuth2Tokens {
 	}
 
 	public accessTokenExpiresInSeconds(): number {
-		if ("expires_in" in this.data && typeof this.data.expires_in === "number") {
-			return this.data.expires_in;
+		if ("expires_in" in this.data) {
+			const expires_in = parseInt(`${this.data.expires_in}`);
+
+			if (typeof expires_in === "number" && !Number.isNaN(expires_in)) {
+				return expires_in;
+			}
 		}
 		throw new Error("Missing or invalid 'expires_in' field");
 	}

--- a/src/providers/naver.ts
+++ b/src/providers/naver.ts
@@ -16,22 +16,20 @@ export class Naver {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string): URL {
+	public createAuthorizationURL(): URL {
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("redirect_uri", this.redirectURI);
-		url.searchParams.set("state", state);
 		return url;
 	}
 
-	public async validateAuthorizationCode(state: string, code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		body.set("code", code);
-		body.set("state", state);
 		body.set("redirect_uri", this.redirectURI);
 		const request = createOAuth2Request(tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);

--- a/src/providers/naver.ts
+++ b/src/providers/naver.ts
@@ -18,42 +18,34 @@ export class Naver {
 
 	public createAuthorizationURL(state: string): URL {
 		const url = new URL(authorizationEndpoint);
-
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("redirect_uri", this.redirectURI);
 		url.searchParams.set("state", state);
-
 		return url;
 	}
 
 	public async validateAuthorizationCode(state: string, code: string): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
-
 		body.set("grant_type", "authorization_code");
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		body.set("code", code);
 		body.set("state", state);
 		body.set("redirect_uri", this.redirectURI);
-
 		const request = createOAuth2Request(tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
-
 		return tokens;
 	}
 
 	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
-
 		body.set("grant_type", "refresh_token");
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		body.set("refresh_token", refreshToken);
-
 		const request = createOAuth2Request(tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
-
 		return tokens;
 	}
 }

--- a/src/providers/naver.ts
+++ b/src/providers/naver.ts
@@ -1,0 +1,59 @@
+import { createOAuth2Request, sendTokenRequest } from "../request.js";
+
+import type { OAuth2Tokens } from "../oauth2.js";
+
+const authorizationEndpoint = "https://nid.naver.com/oauth2.0/authorize";
+const tokenEndpoint = "https://nid.naver.com/oauth2.0/token";
+
+export class Naver {
+	private clientId: string;
+	private clientSecret: string;
+	private redirectURI: string;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string) {
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+		this.redirectURI = redirectURI;
+	}
+
+	public createAuthorizationURL(state: string): URL {
+		const url = new URL(authorizationEndpoint);
+
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("client_id", this.clientId);
+		url.searchParams.set("redirect_uri", this.redirectURI);
+		url.searchParams.set("state", state);
+
+		return url;
+	}
+
+	public async validateAuthorizationCode(state: string, code: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+
+		body.set("grant_type", "authorization_code");
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		body.set("code", code);
+		body.set("state", state);
+		body.set("redirect_uri", this.redirectURI);
+
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+
+		body.set("grant_type", "refresh_token");
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		body.set("refresh_token", refreshToken);
+
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+
+		return tokens;
+	}
+}


### PR DESCRIPTION
Hi! I've been using `arctic` for a personal project, and since I needed support for the Naver provider, I submitted a PR for it.

- Add Naver provider
  - Naver is a major portal site in South Korea, offering a variety of services such as a search engine, news, shopping, blogs, and community forums
- Fix `accessTokenExpiresInSeconds` to parse numbers from strings
  - The Naver provider returns `expires_in` as a string-formatted number, which caused an issue when calling `accessTokenExpiresInSeconds`. I updated it to handle parsing numbers from strings.

**Note**

Naver returns the oauth2 token data like this:

```ts
{
    access_token: '***********',
    refresh_token: '**********',
    token_type: 'bearer',
    expires_in: '3600'
  }
```