### PR TITLE
fix dropbox access type

### DIFF
--- a/docs/pages/providers/dropbox.md
+++ b/docs/pages/providers/dropbox.md
@@ -97,7 +97,7 @@ Set the `access_type` parameter to `offline` to get refresh tokens.
 
 ```ts
 const url = dropbox.createAuthorizationURL(state, scopes);
-url.searchParams.set("access_type", "offline");
+url.searchParams.set("token_access_type", "offline");
 ```
 
 ```ts

--- a/docs/pages/providers/dropbox.md
+++ b/docs/pages/providers/dropbox.md
@@ -93,7 +93,7 @@ The [`/users/get_current_account` endpoint](https://www.dropbox.com/developers/d
 
 ## Refresh access tokens
 
-Set the `access_type` parameter to `offline` to get refresh tokens.
+Set the `token_access_type` parameter to `offline` to get refresh tokens.
 
 ```ts
 const url = dropbox.createAuthorizationURL(state, scopes);


### PR DESCRIPTION
I think when using Dropbox via oauth the way to get the refresh token is by setting `token_access_type=offline` and not `access_type=offline`

The source is this [article](https://developers.dropbox.com/oauth-guide) from dropbox