### PR TITLE
Fix the Authentik provider docs.

### DIFF
--- a/docs/pages/providers/authentik.md
+++ b/docs/pages/providers/authentik.md
@@ -2,7 +2,7 @@
 title: "Authentik"
 ---
 
-# Okta
+# Authentik
 
 OAuth 2.0 provider for Authentik.
 


### PR DESCRIPTION
The title on the Authentik page said Okta, now it says Authentik.