### PR TITLE
Fix empty response in sendTokenRevocationRequest

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -47,7 +47,7 @@ export async function sendTokenRevocationRequest(request: Request): Promise<void
 	} catch (e) {
 		throw new ArcticFetchError(e);
 	}
-	if (response.ok && response.body === null) {
+	if (response.ok && (response.body === null || response.headers.get("Content-Length") === "0")) {
 		return;
 	}
 	let data: unknown;


### PR DESCRIPTION
When revoking a token with a custom provider, the response comes back as empty. The code does a check for `response.body === null` but `body` will always be a `ReadableStream` (at least in runtimes like Bun) even if it's empty.

Checking for content-length is more reliable.

This PR still leaves the old method to avoid any breaking changes