### PR TITLE
fix: lichess client_id required error

### DIFF
--- a/src/providers/lichess.ts
+++ b/src/providers/lichess.ts
@@ -32,6 +32,7 @@ export class Lichess {
 		codeVerifier: string
 	): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
+		body.set("client_id", this.clientId);
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);
 		body.set("code_verifier", codeVerifier);


### PR DESCRIPTION
client_id needs to be passed to accessToken request