### PR TITLE
use form post if scopes include email or name

### DIFF
--- a/src/providers/apple.ts
+++ b/src/providers/apple.ts
@@ -34,6 +34,9 @@ export class Apple {
 		url.searchParams.set("state", state);
 		url.searchParams.set("scope", scopes.join(" "));
 		url.searchParams.set("redirect_uri", this.redirectURI);
+		if (scopes.some((scope) => ["email", "name"].includes(scope))) {
+			url.searchParams.set("response_mode", "form_post");
+		}
 		return url;
 	}
 


### PR DESCRIPTION
Fixes #214 by setting the response_mode to form_post if the scopes includes email or name.