### PR TITLE
feat(providers): add mercado pago

### DIFF
--- a/docs/pages/providers/mercado-pago.md
+++ b/docs/pages/providers/mercado-pago.md
@@ -29,14 +29,14 @@ const url = mercadoPago.createAuthorizationURL(state, codeVerifier, scopes);
 
 ## Validate authorization code
 
-`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Strava returns an access token, the access token expiration, and a refresh token.
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Mercado Pago returns an access token, the access token expiration, and a refresh token.
 
 ```ts
 import { OAuth2RequestError, ArcticFetchError } from "arctic";
 
 let tokens: OAuth2Tokens
 try {
-	tokens = await strava.validateAuthorizationCode(code, codeVerifier);
+	tokens = await mercadoPago.validateAuthorizationCode(code, codeVerifier);
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {
 		// Invalid authorization code, credentials, or redirect URI
@@ -57,7 +57,7 @@ const refreshToken = tokens.refreshToken();
 
 ## Refresh access tokens
 
-Use `refreshAccessToken()` to get a new access token using a refresh token. Strava returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+Use `refreshAccessToken()` to get a new access token using a refresh token. Mercado Pago returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
 
 ```ts
 import { OAuth2RequestError, ArcticFetchError } from "arctic";

--- a/docs/pages/providers/mercado-pago.md
+++ b/docs/pages/providers/mercado-pago.md
@@ -1,0 +1,81 @@
+---
+title: "Mercado Pago"
+---
+
+# Mercado Pago
+
+OAuth 2.0 provider for Mercado Pago.
+
+Also see the [OAuth 2.0](/guides/oauth2) guide.
+
+## Initialization
+
+```ts
+import { MercadoPago } from "arctic";
+
+const mercadoPago = new MercadoPago(clientId, clientSecret, redirectURI);
+```
+
+## Create authorization URL
+
+```ts
+import { generateState } from "arctic";
+
+const state = generateState();
+const codeVerifier = generateCodeVerifier()
+const scopes = ["read"];
+const url = mercadoPago.createAuthorizationURL(state, codeVerifier, scopes);
+```
+
+## Validate authorization code
+
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). Strava returns an access token, the access token expiration, and a refresh token.
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+let tokens: OAuth2Tokens
+try {
+	tokens = await strava.validateAuthorizationCode(code, codeVerifier);
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+		const code = e.code;
+		// ...
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+		const cause = e.cause;
+		// ...
+	}
+	// Parse error
+}
+const accessToken = tokens.accessToken();
+const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+const refreshToken = tokens.refreshToken();
+```
+
+## Refresh access tokens
+
+Use `refreshAccessToken()` to get a new access token using a refresh token. Strava returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+
+let tokens: OAuth2Tokens
+try {
+	tokens = await strava.refreshAccessToken(refreshToken);
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+	}
+	// Parse error
+}
+const accessToken = tokens.accessToken();
+const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+const refreshToken = tokens.refreshToken();
+```

--- a/src/providers/mercado-pago.ts
+++ b/src/providers/mercado-pago.ts
@@ -1,0 +1,62 @@
+import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Tokens } from "../oauth2.js";
+import { createOAuth2Request, sendTokenRequest } from "../request.js";
+
+const authorizationEndpoint = "https://auth.mercadopago.com.ar/authorization";
+const tokenEndpoint = "https://api.mercadopago.com/oauth/token";
+
+export class MercadoPago {
+	public clientId: string;
+
+	private client: OAuth2Client;
+	private clientSecret: string;
+	private redirectURI: string;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string) {
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+		this.redirectURI = redirectURI;
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURLWithPKCE(
+			authorizationEndpoint,
+			state,
+			CodeChallengeMethod.S256,
+			codeVerifier,
+			scopes
+		);
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string
+	): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("grant_type", "authorization_code");
+		body.set("code", code);
+		body.set("redirect_uri", this.redirectURI);
+		body.set("code_verifier", codeVerifier);
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async refreshAccessToken(
+		tokenEndpoint: string,
+		refreshToken: string
+	): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("grant_type", "refresh_token");
+		body.set("refresh_token", refreshToken);
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+}

--- a/src/providers/mercado-pago.ts
+++ b/src/providers/mercado-pago.ts
@@ -47,7 +47,6 @@ export class MercadoPago {
 	}
 
 	public async refreshAccessToken(
-		tokenEndpoint: string,
 		refreshToken: string
 	): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();


### PR DESCRIPTION
This PR adds the provider for the non-standard Mercado Pago's OAuth2 flow, found [here](https://www.mercadopago.com.ar/developers/en/reference/oauth/_oauth_token/post). This is a highly used payment system in Latin America

