### PR TITLE
feat: support all params for cognito /authorize and /token

### DIFF
--- a/docs/pages/providers/amazon-cognito.md
+++ b/docs/pages/providers/amazon-cognito.md
@@ -110,7 +110,7 @@ const claims = decodeIdToken(idToken);
 ```
 
 ```ts
-const response = await fetch(userPool + "/oauth/userInfo", {
+const response = await fetch(userPool + "/oauth2/userInfo", {
 	headers: {
 		Authorization: `Bearer ${accessToken}`
 	}

--- a/docs/pages/providers/amazon-cognito.md
+++ b/docs/pages/providers/amazon-cognito.md
@@ -16,7 +16,12 @@ The user pool should not include trailing slashes.
 import { AmazonCognito } from "arctic";
 
 const userPool = "https://cognito-idp.{region}.amazonaws.com/{pool-id}";
-const cognito = new AmazonCognito(userPool, clientId, clientSecret, redirectURI);
+const cognito = new AmazonCognito({
+	userPool,
+	clientId,
+	clientSecret,
+	redirectURI
+});
 ```
 
 ## Create authorization URL
@@ -27,7 +32,11 @@ import { generateState, generateCodeVerifier } from "arctic";
 const state = generateState();
 const codeVerifier = generateCodeVerifier();
 const scopes = ["openid", "profile"];
-const url = cognito.createAuthorizationURL(state, codeVerifier, scopes);
+const url = cognito.createAuthorizationURL({
+	state,
+	codeVerifier,
+	scopes
+});
 ```
 
 ## Validate authorization code
@@ -85,7 +94,11 @@ Use OpenID Connect with the `openid` scope to get the user's profile with an ID 
 
 ```ts
 const scopes = ["openid"];
-const url = cognito.createAuthorizationURL(state, codeVerifier, scopes);
+const url = cognito.createAuthorizationURL({
+	state,
+	codeVerifier,
+	scopes
+});
 ```
 
 ```ts

--- a/src/providers/amazon-cognito.ts
+++ b/src/providers/amazon-cognito.ts
@@ -7,36 +7,75 @@ import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } fro
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
+type AmazonCognitoOptions = {
+	userPool: string;
+	clientId: string;
+	clientSecret?: string;
+	redirectURI: string;
+}
+
+type CreateAuthorizationURLOptions = {
+	codeVerifier: string;
+	identityProvider?: string;
+	idpIdentifier?: string;
+	lang?: string;
+	loginHint?: string;
+	nonce?: string;
+	scopes: string[];
+	state: string;
+}
+
+type RefreshAccessTokenOptions = {
+	codeVerifier?: string;
+	code: string;
+	refreshToken: string;
+	scopes?: string[];
+}
 export class AmazonCognito {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
 
 	private clientId: string;
-	private clientSecret: string;
+	private clientSecret?: string;
 	private redirectURI: string;
 
-	constructor(userPool: string, clientId: string, clientSecret: string, redirectURI: string) {
-		this.authorizationEndpoint = userPool + "/oauth2/authorize";
-		this.tokenEndpoint = userPool + "/oauth2/token";
-		this.tokenRevocationEndpoint = userPool + "/oauth2/revoke";
+	constructor(options: AmazonCognitoOptions) {
+		this.authorizationEndpoint = options.userPool + "/oauth2/authorize";
+		this.tokenEndpoint = options.userPool + "/oauth2/token";
+		this.tokenRevocationEndpoint = options.userPool + "/oauth2/revoke";
 
-		this.clientId = clientId;
-		this.clientSecret = clientSecret;
-		this.redirectURI = redirectURI;
+		this.clientId = options.clientId;
+		this.clientSecret = options.clientSecret;
+		this.redirectURI = options.redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: CreateAuthorizationURLOptions): URL {
 		const url = new URL(this.authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("redirect_uri", this.redirectURI);
-		url.searchParams.set("state", state);
-		const codeChallenge = createS256CodeChallenge(codeVerifier);
+		url.searchParams.set("state", options.state);
+		const codeChallenge = createS256CodeChallenge(options.codeVerifier);
 		url.searchParams.set("code_challenge_method", "S256");
 		url.searchParams.set("code_challenge", codeChallenge);
-		if (scopes.length > 0) {
-			url.searchParams.set("scope", scopes.join(" "));
+		if (options.scopes.length > 0) {
+			url.searchParams.set("scope", options.scopes.join(" "));
+		}
+		if (options.loginHint) {
+			url.searchParams.set("login_hint", options.loginHint);
+		}
+		if (options.nonce) {
+			url.searchParams.set("nonce", options.nonce);
+		}
+		if (options.lang) {
+			url.searchParams.set("lang", options.lang);
+		}
+		if (options.identityProvider) {
+			url.searchParams.set("identity_provider", options.identityProvider);
+		}
+		if (options.idpIdentifier) {
+			url.searchParams.set("idp_identifier", options.idpIdentifier);
 		}
 		return url;
 	}
@@ -51,19 +90,32 @@ export class AmazonCognito {
 		body.set("redirect_uri", this.redirectURI);
 		body.set("code_verifier", codeVerifier);
 		body.set("client_id", this.clientId);
-		body.set("client_secret", this.clientSecret);
+		if (this.clientSecret) {
+			body.set("client_secret", this.clientSecret);
+		}
 		const request = createOAuth2Request(this.tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}
 
-	// TODO: Add `scopes` parameter
-	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+	public async refreshAccessToken(options: RefreshAccessTokenOptions): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "refresh_token");
-		body.set("refresh_token", refreshToken);
 		body.set("client_id", this.clientId);
-		body.set("client_secret", this.clientSecret);
+		if (this.clientSecret) {
+			body.set("client_secret", this.clientSecret);
+		}
+		if (options.scopes && options.scopes.length > 0) {
+			body.set("scope", options.scopes.join(" "));
+		}
+		body.set("redirect_uri", this.redirectURI);
+		body.set("refresh_token", options.refreshToken);
+		if (options.code) {
+			body.set("code", options.code);
+		}
+		if (options.codeVerifier) {
+			body.set("code_verifier", options.codeVerifier);
+		}
 		const request = createOAuth2Request(this.tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
 		return tokens;
@@ -73,7 +125,6 @@ export class AmazonCognito {
 		const body = new URLSearchParams();
 		body.set("token", token);
 		body.set("client_id", this.clientId);
-		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(this.tokenRevocationEndpoint, body);
 		await sendTokenRevocationRequest(request);
 	}


### PR DESCRIPTION
@pilcrowonpaper thank you for this excellent library

i use cognito frequently for saml oauth and most of my app clients don't have a `client_secret`

i want to use `artic` across my projects and replace the custom class i usually have for it (similar to the `class AmazonCognito` here)

this PR aims to:

1) making `client_secret` optional, enabling users to create app clients with and without secret

2) add support to all params in `/authorize` endpoint

https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html

some of my projects have multiple tenants for different customers, and we use the `identity_provider` to redirect them to the idp directly, without landing on cognito managed login

3) add support to all params in `/token`

https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html

this was a nice to have, while I do use the `redirect_uri` sometimes, but not strictly required

4) remove `client_secret` from `/revoke` endpoint

https://docs.aws.amazon.com/cognito/latest/developerguide/revocation-endpoint.html

`client_secret` is not required as part of the body