### PR TITLE
Add TikTok as an authentication provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Arctic does not strictly follow semantic versioning. While we aim to only introd
 - Spotify
 - Start.gg
 - Strava
+- TikTok
 - Tiltify
 - Tumblr
 - Twitch

--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -61,6 +61,7 @@
 				["Spotify", "/providers/spotify"],
 				["Start.gg", "/providers/startgg"],
 				["Strava", "/providers/strava"],
+				["TikTok", "/providers/tiktok"],
 				["Tiltify", "/providers/tiltify"],
 				["Tumblr", "/providers/tumblr"],
 				["Twitch", "/providers/twitch"],

--- a/docs/pages/providers/tiktok.md
+++ b/docs/pages/providers/tiktok.md
@@ -1,0 +1,109 @@
+---
+title: "TikTok"
+---
+
+# TikTok
+
+OAuth 2.0 provider for TikTok.
+
+Also see the [OAuth 2.0](/guides/oauth2) guide.
+
+## Initialization
+
+```ts
+import { TikTok } from "arctic";
+
+const tiktok = new TikTok(clientKey, clientSecret, redirectURI);
+```
+
+## Create authorization URL
+
+```ts
+import { generateState } from "arctic";
+
+const state = generateState();
+const scopes = ["user.info.basic"];
+const url = tiktok.createAuthorizationURL(state, scopes);
+```
+
+## Validate authorization code
+
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), or a standard `Error` (parse errors). TikTok returns an access token, the access token expiration, and a refresh token.
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+try {
+	const tokens = await tiktok.validateAuthorizationCode(code);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+	const refreshToken = tokens.refreshToken();
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+		const code = e.code;
+		// ...
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+		const cause = e.cause;
+		// ...
+	}
+	// Parse error
+}
+```
+
+## Refresh access tokens
+
+Use `refreshAccessToken()` to get a new access token using a refresh token. TikTok returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+
+```ts
+import { OAuth2RequestError, ArcticFetchError } from "arctic";
+
+try {
+	const tokens = await tiktok.refreshAccessToken(refreshToken);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+	const refreshToken = tokens.refreshToken();
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+	}
+	// Parse error
+}
+```
+
+## Get user profile
+
+Use the [`/user/info/` endpoint](https://developers.tiktok.com/doc/login-kit-web/#get-user-info).
+
+```ts
+const response = await fetch("https://open-api.tiktok.com/user/info/", {
+	body: JSON.stringify({
+		access_token: "token",
+		fields: ["open_id", "avatar_url"],
+	})
+});
+const user = await response.json();
+```
+
+## Revoke tokens
+
+Pass a token to `revokeToken()` to revoke all tokens associated with the authorization. This can throw the same errors as `validateAuthorizationCode()`.
+
+```ts
+try {
+	await tiktok.revokeToken(token);
+} catch (e) {
+	if (e instanceof OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+	}
+	if (e instanceof ArcticFetchError) {
+		// Failed to call `fetch()`
+	}
+	// Parse error
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export { Yahoo } from "./providers/yahoo.js";
 export { Yandex } from "./providers/yandex.js";
 export { Zoom } from "./providers/zoom.js";
 export { FortyTwo } from "./providers/42.js";
+export { TikTok } from "./providers/tiktok.js";
 
 export { OAuth2Client, CodeChallengeMethod } from "./client.js";
 export { OAuth2Tokens, generateCodeVerifier, generateState } from "./oauth2.js";

--- a/src/providers/tiktok.ts
+++ b/src/providers/tiktok.ts
@@ -1,0 +1,62 @@
+import { OAuth2Client } from "../client.js";
+
+import type { OAuth2Tokens } from "../oauth2.js";
+import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
+
+const authorizationEndpoint = "https://www.tiktok.com/v2/auth/authorize/";
+const tokenEndpoint = "https://open.tiktokapis.com/v2/oauth/token/";
+const revokeEndpoint = "https://open.tiktokapis.com/v2/oauth/revoke/";
+
+export class TikTok {
+	private clientKey: string;
+	private clientSecret: string;
+	private redirectURI: string;
+
+	constructor(clientKey: string, clientSecret: string, redirectURI: string) {
+		this.clientKey = clientKey;
+		this.clientSecret = clientSecret;
+		this.redirectURI = redirectURI;
+	}
+
+	public createAuthorizationURL(state: string, scopes: string[]): URL {
+		const url = new URL(authorizationEndpoint);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("client_key", this.clientKey);
+		url.searchParams.set("state", state);
+		url.searchParams.set("scope", scopes.join(","));
+		url.searchParams.set("redirect_uri", this.redirectURI);
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("grant_type", "authorization_code");
+		body.set("code", code);
+		body.set("redirect_uri", this.redirectURI);
+		body.set("client_key", this.clientKey);
+		body.set("client_secret", this.clientSecret);
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("grant_type", "refresh_token");
+		body.set("refresh_token", refreshToken);
+		body.set("client_key", this.clientKey);
+		body.set("client_secret", this.clientSecret);
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		const body = new URLSearchParams();
+		body.set("token", token);
+		body.set("client_key", this.clientKey);
+		body.set("client_secret", this.clientSecret);
+		const request = createOAuth2Request(revokeEndpoint, body);
+		await sendTokenRevocationRequest(request);
+	}
+}


### PR DESCRIPTION
Fixes #162

Adds tiktok as a provider. Started with Github Copilor Workspace, finalized manually (had to change most of the stuff). It also includes a documentation. Needs testing (will do really soon)

References:

- https://developers.tiktok.com/doc/login-kit-web?enter_method=left_navigation
- https://developers.tiktok.com/doc/login-kit-manage-user-access-tokens
- https://developers.tiktok.com/doc/tiktok-api-v1-user-info