### PR TITLE
fix: export TikTok provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { Slack } from "./providers/slack.js";
 export { Spotify } from "./providers/spotify.js";
 export { StartGG } from "./providers/startgg.js";
 export { Strava } from "./providers/strava.js";
+export { TikTok } from "./providers/tiktok.js";
 export { Tiltify } from "./providers/tiltify.js";
 export { Tumblr } from "./providers/tumblr.js";
 export { Twitch } from "./providers/twitch.js";


### PR DESCRIPTION
It adds the missing export of the TikTok provider from the `index.ts`, so it's available via

`import { TikTok } from 'arctic'`

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [X] Please tick this box if you’ve read and understood this section..
