### PR TITLE
fix: tiktok provider

### DIFF
--- a/src/providers/tiktok.ts
+++ b/src/providers/tiktok.ts
@@ -27,7 +27,7 @@ export class TikTok {
 		url.searchParams.set("code_challenge_method", "S256");
 		url.searchParams.set("code_challenge", codeChallenge);
 		if (scopes.length > 0) {
-			url.searchParams.set("scope", scopes.join(" "));
+			url.searchParams.set("scope", scopes.join(","));
 		}
 		url.searchParams.set("redirect_uri", this.redirectURI);
 		return url;

--- a/src/providers/tiktok.ts
+++ b/src/providers/tiktok.ts
@@ -4,8 +4,8 @@ import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } fro
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.tiktok.com/v2/auth/authorize";
-const tokenEndpoint = "https://open.tiktokapis.com/v2/oauth/token";
-const tokenRevocationEndpoint = "https://open.tiktokapis.com/v2/oauth/revoke";
+const tokenEndpoint = "https://open.tiktokapis.com/v2/oauth/token/";
+const tokenRevocationEndpoint = "https://open.tiktokapis.com/v2/oauth/revoke/";
 
 export class TikTok {
 	private clientKey: string;


### PR DESCRIPTION
This fixes the invalid scopes parameter send to the TikTok API. I noticed it while using the TikTok provider by myself and getting an invalid request:

![CleanShot 2025-01-14 at 20 22 07](https://github.com/user-attachments/assets/85874c16-da16-4245-9aab-281c0352b741)

TikTok expects a comma-separated string of scopes, instead of an empty string e.g `user.info.basic,user.info.stats` instead of `user.info.basic user.info.stats`.

Source: https://developers.tiktok.com/doc/login-kit-web
![CleanShot 2025-01-14 at 20 18 17](https://github.com/user-attachments/assets/9a649263-ec18-4615-9c44-50ba54596a58)

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [X] Please tick this box if you’ve read and understood this section..
