### PR TITLE
Add DonationAlerts provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Arctic does not strictly follow semantic versioning. While we aim to only introd
 - Bungie
 - Coinbase
 - Discord
+- DonationAlerts
 - Dribbble
 - Dropbox
 - Etsy

--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -30,6 +30,7 @@
 				["Bungie", "/providers/bungie"],
 				["Coinbase", "/providers/coinbase"],
 				["Discord", "/providers/discord"],
+				["DonationAlerts", "/providers/donation-alerts"],
 				["Dribbble", "/providers/dribbble"],
 				["Dropbox", "/providers/dropbox"],
 				["Epic Games", "/providers/epicgames"],

--- a/docs/pages/providers/donation-alerts.md
+++ b/docs/pages/providers/donation-alerts.md
@@ -21,8 +21,9 @@ const donationAlerts = new arctic.DonationAlerts(clientId, clientSecret, redirec
 ```ts
 import * as arctic from "arctic";
 
+const state = arctic.generateState();
 const scopes = ["oauth-user-show"];
-const url = donationAlerts.createAuthorizationURL(scopes);
+const url = donationAlerts.createAuthorizationURL(state, scopes);
 ```
 
 ## Validate authorization code
@@ -77,21 +78,17 @@ try {
 
 ### Get user profile
 
-Add the `oauth-user-show` scope when creating the authorization URL.
+Add the `oauth-user-show` scope and use the [`/user/oauth`](https://www.donationalerts.com/apidoc#api_v1__users__user_profile_information) endpoint.
 
 ```ts
 const scopes = ["oauth-user-show"];
-const url = donationAlerts.createAuthorizationURL(scopes);
+const url = donationAlerts.createAuthorizationURL(state, scopes);
 ```
 
-Then in your callback make a request to the DonationAlerts API.
-
 ```ts
-const tokens = await donationAlerts.validateAuthorizationCode(code);
-
 const response = await fetch("https://www.donationalerts.com/api/v1/user/oauth", {
 	headers: {
-		Authorization: `Bearer ${tokens.accessToken()}`
+		Authorization: `Bearer ${accessToken}`
 	}
 });
 const user = await response.json();

--- a/docs/pages/providers/donation-alerts.md
+++ b/docs/pages/providers/donation-alerts.md
@@ -60,7 +60,8 @@ Use `refreshAccessToken()` to get a new access token using a refresh token. Dona
 import * as arctic from "arctic";
 
 try {
-	const tokens = await donationAlerts.refreshAccessToken(refreshToken);
+	const scopes = ["oauth-user-show"];
+	const tokens = await donationAlerts.refreshAccessToken(refreshToken, scopes);
 	const accessToken = tokens.accessToken();
 	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
 } catch (e) {

--- a/docs/pages/providers/donation-alerts.md
+++ b/docs/pages/providers/donation-alerts.md
@@ -1,0 +1,97 @@
+---
+title: "DonationAlerts"
+---
+
+# DonationAlerts
+
+OAuth 2.0 provider for DonationAlerts.
+
+Also see the [OAuth 2.0](/guides/oauth2) guide.
+
+## Initialization
+
+```ts
+import * as arctic from "arctic";
+
+const donationAlerts = new arctic.DonationAlerts(clientId, clientSecret, redirectURI);
+```
+
+## Create authorization URL
+
+```ts
+import * as arctic from "arctic";
+
+const scopes = ["oauth-user-show"];
+const url = donationAlerts.createAuthorizationURL(scopes);
+```
+
+## Validate authorization code
+
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), [`UnexpectedResponseError`](/reference/main/UnexpectedResponseError), or [`UnexpectedErrorResponseBodyError`](/reference/main/UnexpectedErrorResponseBodyError). DonationAlerts returns an access token, the access token expiration, and a refresh token.
+
+```ts
+import * as arctic from "arctic";
+
+try {
+	const tokens = await donationAlerts.validateAuthorizationCode(code);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+	const refreshToken = tokens.refreshToken();
+} catch (e) {
+	if (e instanceof arctic.OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+		const code = e.code;
+		// ...
+	}
+	if (e instanceof arctic.ArcticFetchError) {
+		// Failed to call `fetch()`
+		const cause = e.cause;
+		// ...
+	}
+	// Parse error
+}
+```
+
+## Refresh access tokens
+
+Use `refreshAccessToken()` to get a new access token using a refresh token. DonationAlerts returns the same values as during the authorization code validation. This method also returns `OAuth2Tokens` and throws the same errors as `validateAuthorizationCode()`
+
+```ts
+import * as arctic from "arctic";
+
+try {
+	const tokens = await donationAlerts.refreshAccessToken(refreshToken);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+} catch (e) {
+	if (e instanceof arctic.OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+	}
+	if (e instanceof arctic.ArcticFetchError) {
+		// Failed to call `fetch()`
+	}
+	// Parse error
+}
+```
+
+### Get user profile
+
+Add the `oauth-user-show` scope when creating the authorization URL.
+
+```ts
+const scopes = ["oauth-user-show"];
+const url = donationAlerts.createAuthorizationURL(scopes);
+```
+
+Then in your callback make a request to the DonationAlerts API.
+
+```ts
+const tokens = await donationAlerts.validateAuthorizationCode(code);
+
+const response = await fetch("https://www.donationalerts.com/api/v1/user/oauth", {
+	headers: {
+		Authorization: `Bearer ${tokens.accessToken()}`
+	}
+});
+const user = await response.json();
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { Box } from "./providers/box.js";
 export { Bungie } from "./providers/bungie.js";
 export { Coinbase } from "./providers/coinbase.js";
 export { Discord } from "./providers/discord.js";
+export { DonationAlerts } from "./providers/donation-alerts.js";
 export { Dribbble } from "./providers/dribbble.js";
 export { Dropbox } from "./providers/dropbox.js";
 export { Etsy } from "./providers/etsy.js";

--- a/src/providers/donation-alerts.ts
+++ b/src/providers/donation-alerts.ts
@@ -1,0 +1,52 @@
+import { createOAuth2Request, sendTokenRequest } from "../request.js";
+
+import type { OAuth2Tokens } from "../oauth2.js";
+
+const authorizationEndpoint = "https://www.donationalerts.com/oauth/authorize";
+const tokenEndpoint = "https://www.donationalerts.com/oauth/token";
+
+export class DonationAlerts {
+	private clientId: string;
+	private clientSecret: string;
+	private redirectURI: string;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string) {
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+		this.redirectURI = redirectURI;
+	}
+
+	public createAuthorizationURL(scopes: string[]): URL {
+		const url = new URL(authorizationEndpoint);
+		url.searchParams.set("client_id", this.clientId);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("redirect_uri", this.redirectURI);
+		if (scopes.length > 0) {
+			url.searchParams.set("scope", scopes.join(" "));
+		}
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("code", code);
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		body.set("redirect_uri", this.redirectURI);
+		body.set("grant_type", "authorization_code");
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set("refresh_token", refreshToken);
+		body.set("client_id", this.clientId);
+		body.set("client_secret", this.clientSecret);
+		body.set("grant_type", "refresh_token");
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+}

--- a/src/providers/donation-alerts.ts
+++ b/src/providers/donation-alerts.ts
@@ -18,33 +18,32 @@ export class DonationAlerts {
 
 	public createAuthorizationURL(scopes: string[]): URL {
 		const url = new URL(authorizationEndpoint);
-		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("response_type", "code");
+		url.searchParams.set("client_id", this.clientId);
+		url.searchParams.set("scope", scopes.join(" "));
 		url.searchParams.set("redirect_uri", this.redirectURI);
-		if (scopes.length > 0) {
-			url.searchParams.set("scope", scopes.join(" "));
-		}
 		return url;
 	}
 
 	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
+		body.set("grant_type", "authorization_code");
 		body.set("code", code);
+		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
-		body.set("redirect_uri", this.redirectURI);
-		body.set("grant_type", "authorization_code");
 		const request = createOAuth2Request(tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}
 
-	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+	public async refreshAccessToken(refreshToken: string, scopes: string[]): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
+		body.set("grant_type", "refresh_token");
 		body.set("refresh_token", refreshToken);
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
-		body.set("grant_type", "refresh_token");
+		body.set("scope", scopes.join(" "));
 		const request = createOAuth2Request(tokenEndpoint, body);
 		const tokens = await sendTokenRequest(request);
 		return tokens;


### PR DESCRIPTION
Docs: https://www.donationalerts.com/apidoc#authorization
User Profile Information: https://www.donationalerts.com/apidoc#api_v1__users__user_profile_information

The docs says that `client_id` should be a number but I left it as a string like in every other provider.

`scope` for `Authorization Request` and `Refreshing Access Tokens` is marked as required.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
