### PR TITLE
Fix typo in Patreon documentation

### DIFF
--- a/docs/pages/providers/patreon.md
+++ b/docs/pages/providers/patreon.md
@@ -22,7 +22,7 @@ const patreon = new arctic.Patreon(clientId, clientSecret, redirectURI);
 import * as arctic from "arctic";
 
 const state = arctic.generateState();
-const scopes = ["identify", "identity[email]"];
+const scopes = ["identity", "identity[email]"];
 const url = patreon.createAuthorizationURL(state, scopes);
 ```
 
@@ -81,7 +81,7 @@ try {
 Add the `identity` scope and use the [`/api/oauth2/v2/identity` endpoint](https://docs.patreon.com/#get-api-oauth2-v2-identity). Optionally add the `identity[email]` scope to get user email.
 
 ```ts
-const scopes = ["identify", "identity[email]"];
+const scopes = ["identity", "identity[email]"];
 const url = patreon.createAuthorizationURL(state, scopes);
 ```
 


### PR DESCRIPTION
# Summary
In the Patreon provider documentation, the first item in the example scope array is set to `identify`. However, it needs to be changed to `identity`. This is even mentioned in the "Get User Profile" section. Currently, the requests receive an error from the Patreon API.

> ### Get user profile
> Add the identity scope and use the [/api/oauth2/v2/identity endpoint](https://docs.patreon.com/#get-api-oauth2-v2-identity). Optionally add the identity[email] scope to get user email.


PS: This is also my first open source contribution to any project ever! 🎉 However, if I didn't go about this correctly, please let me know and I'm happy to adjust the PR.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [ ✅] Please tick this box if you’ve read and understood this section..
