### PR TITLE
Clarify Roblox OAuth API lacks email scope

### DIFF
--- a/docs/pages/providers/roblox.md
+++ b/docs/pages/providers/roblox.md
@@ -107,10 +107,11 @@ const user = await response.json();
 
 ### Get user profile
 
-Make sure to add the `profile` scope to get the user profile and the `email` scope to get the user email.
+Make sure to add the `profile` scope to get the user profile. The Roblox API does
+not provide an email address.
 
 ```ts
-const scopes = ["openid", "profile", "email"];
+const scopes = ["openid", "profile"];
 const url = roblox.createAuthorizationURL(state, codeVerifier, scopes);
 ```
 


### PR DESCRIPTION
Update documentation to remove email scope from 'Get User Profile' section as the Roblox OAuth API does not provide access to email addresses.

The email scope is in the API, but only official Roblox apps can access it.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
