### PR TITLE
Fix: Correct authorization endpoint URL in StartGG and Tiltify provider

### DIFF
--- a/src/providers/startgg.ts
+++ b/src/providers/startgg.ts
@@ -2,7 +2,7 @@ import { createOAuth2Request, sendTokenRequest } from "../request.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-const authorizationEndpoint = "https://start.gg/oauth/authoriz";
+const authorizationEndpoint = "https://start.gg/oauth/authorize";
 const tokenEndpoint = "https://api.start.gg/oauth/access_token";
 const refreshEndpoint = "https://api.start.gg/oauth/refresh";
 

--- a/src/providers/tiltify.ts
+++ b/src/providers/tiltify.ts
@@ -2,7 +2,7 @@ import { createOAuth2Request, sendTokenRequest } from "../request.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-const authorizationEndpoint = "https://v5api.tiltify.com/oauth/authorizeze";
+const authorizationEndpoint = "https://v5api.tiltify.com/oauth/authorize";
 const tokenEndpoint = "https://v5api.tiltify.com/oauth/token";
 
 export class Tiltify {


### PR DESCRIPTION
The authorization endpoint was missing the trailing `e` in the start.gg which made the endpoint not work correctly. Similarly the Tiltify authorization endpoint had an extra trailing `ze`.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [X] Please tick this box if you’ve read and understood this section..
