### PR TITLE
Refactor WorkOS class to use OAuth sign in instead of SSO

### DIFF
--- a/src/providers/workos.ts
+++ b/src/providers/workos.ts
@@ -9,7 +9,7 @@ export class WorkOS {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 
-	constructor(domain:string,clientId: string, clientSecret: string | null, redirectURI: string) {
+	constructor(domain:string, clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.clientId = clientId;
 		this.clientSecret = clientSecret;
 		this.redirectURI = redirectURI;


### PR DESCRIPTION
The current implementation of WorkOS is using the Single Sign On endpoints. Given that arctic is an OAuth library I figured you would want to use the OAuth routes. Reference for everything I implemented came from here https://workos.com/docs/reference/workos-connect. The OAuth authorization and token endpoint need the apps specific domain so I added it to the constructor parameters. Additionally the authorization route requires a nonce according to the docs so I included it using `crypto.randomUUID()`. I tested these routes in citra / absolute-auth so I can verify they should return the correct data although I did not specifically make an arctic client to test.

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
