### PR TITLE
provider interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,4 @@ export {
 	UnexpectedResponseError
 } from "./request.js";
 export { decodeIdToken } from "./oidc.js";
+export type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "./provider.js";

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,23 @@
+import type { OAuth2Tokens } from "./oauth2.js";
+
+export interface OAuth2AuthorizationOptions {
+	state?: string;
+	scopes?: string[];
+	codeVerifier?: string;
+}
+
+export interface OAuth2ValidationOptions {
+	code?: string;
+	codeVerifier?: string;
+	scopes?: string[];
+}
+
+type TupleToUnion<T extends readonly unknown[]> = T[number];
+
+export interface OAuth2Provider<
+	TAuth extends readonly (keyof OAuth2AuthorizationOptions)[] = readonly (keyof OAuth2AuthorizationOptions)[],
+	TValidation extends readonly (keyof OAuth2ValidationOptions)[] = readonly (keyof OAuth2ValidationOptions)[]
+> {
+	createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, TupleToUnion<TAuth>>): URL;
+	validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, TupleToUnion<TValidation>>): Promise<OAuth2Tokens>;
+}

--- a/src/providers/42.ts
+++ b/src/providers/42.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://api.intra.42.fr/oauth/authorize";
 const tokenEndpoint = "https://api.intra.42.fr/oauth/token";
 
-export class FortyTwo {
+export class FortyTwo implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class FortyTwo {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,7 +30,8 @@ export class FortyTwo {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/amazon-cognito.ts
+++ b/src/providers/amazon-cognito.ts
@@ -1,8 +1,9 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class AmazonCognito {
+export class AmazonCognito implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -17,7 +18,8 @@ export class AmazonCognito {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -29,9 +31,9 @@ export class AmazonCognito {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/anilist.ts
+++ b/src/providers/anilist.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://anilist.co/api/v2/oauth/authorize";
 const tokenEndpoint = "https://anilist.co/api/v2/oauth/token";
 
-export class AniList {
+export class AniList implements OAuth2Provider<["state"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state">): URL {
+		const { state } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, []);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/apple.ts
+++ b/src/providers/apple.ts
@@ -1,13 +1,14 @@
 import * as jwt from "@oslojs/jwt";
 
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://appleid.apple.com/auth/authorize";
 const tokenEndpoint = "https://appleid.apple.com/auth/token";
 
-export class Apple {
+export class Apple implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private teamId: string;
 	private keyId: string;
@@ -28,7 +29,8 @@ export class Apple {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -40,7 +42,8 @@ export class Apple {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/atlassian.ts
+++ b/src/providers/atlassian.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://auth.atlassian.com/authorize";
 const tokenEndpoint = "https://auth.atlassian.com/oauth/token";
 
-export class Atlassian {
+export class Atlassian implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Atlassian {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -30,7 +32,8 @@ export class Atlassian {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/auth0.ts
+++ b/src/providers/auth0.ts
@@ -1,8 +1,9 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Auth0 {
+export class Auth0 implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -15,9 +16,10 @@ export class Auth0 {
 		this.tokenRevocationEndpoint = `https://${domain}/oauth/revoke`;
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
-	public createAuthorizationURL(state: string, codeVerifier: string | null, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		let url: URL;
-		if (codeVerifier !== null) {
+		if (codeVerifier) {
 			url = this.client.createAuthorizationURLWithPKCE(
 				this.authorizationEndpoint,
 				state,
@@ -32,13 +34,13 @@ export class Auth0 {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string | null
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,
-			codeVerifier
+			codeVerifier || null
 		);
 		return tokens;
 	}

--- a/src/providers/authentik.ts
+++ b/src/providers/authentik.ts
@@ -1,9 +1,10 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
 import { joinURIAndPath } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Authentik {
+export class Authentik implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -17,7 +18,8 @@ export class Authentik {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -29,9 +31,9 @@ export class Authentik {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/autodesk.ts
+++ b/src/providers/autodesk.ts
@@ -1,4 +1,5 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,14 +7,15 @@ const authorizationEndpoint = "https://developer.api.autodesk.com/authentication
 const tokenEndpoint = "https://developer.api.autodesk.com/authentication/v2/token";
 const tokenRevocationEndpoint = "https://developer.api.autodesk.com/authentication/v2/revoke";
 
-export class Autodesk {
+export class Autodesk implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -25,9 +27,9 @@ export class Autodesk {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/battlenet.ts
+++ b/src/providers/battlenet.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://oauth.battle.net/authorize";
 const tokenEndpoint = "https://oauth.battle.net/token";
 
-export class BattleNet {
+export class BattleNet implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class BattleNet {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -26,9 +28,10 @@ export class BattleNet {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);

--- a/src/providers/bitbucket.ts
+++ b/src/providers/bitbucket.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://bitbucket.org/site/oauth2/authorize";
 const tokenEndpoint = "https://bitbucket.org/site/oauth2/access_token";
 
-export class Bitbucket {
+export class Bitbucket implements OAuth2Provider<["state"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state">): URL {
+		const { state } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, []);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/box.ts
+++ b/src/providers/box.ts
@@ -1,4 +1,5 @@
 import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,7 +7,7 @@ const authorizationEndpoint = "https://account.box.com/api/oauth2/authorize";
 const tokenEndpoint = "https://api.box.com/oauth2/token";
 const tokenRevocationEndpoint = "https://api.box.com/oauth2/revoke";
 
-export class Box {
+export class Box implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class Box {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,9 +31,10 @@ export class Box {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);

--- a/src/providers/bungie.ts
+++ b/src/providers/bungie.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.bungie.net/en/oauth/authorize";
 const tokenEndpoint = "https://www.bungie.net/platform/app/oauth/token";
 
-export class Bungie {
+export class Bungie implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/coinbase.ts
+++ b/src/providers/coinbase.ts
@@ -1,4 +1,5 @@
 import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,7 +7,7 @@ const authorizationEndpoint = "https://www.coinbase.com/oauth/authorize";
 const tokenEndpoint = "https://www.coinbase.com/oauth/token";
 const tokenRevocationEndpoint = "https://api.coinbase.com/oauth/revoke";
 
-export class Coinbase {
+export class Coinbase implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class Coinbase {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,9 +31,10 @@ export class Coinbase {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -1,4 +1,5 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,16 +7,17 @@ const authorizationEndpoint = "https://discord.com/oauth2/authorize";
 const tokenEndpoint = "https://discord.com/api/oauth2/token";
 const tokenRevocationEndpoint = "https://discord.com/api/oauth2/token/revoke";
 
-export class Discord {
+export class Discord implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string | null, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		let url: URL;
-		if (codeVerifier !== null) {
+		if (codeVerifier) {
 			url = this.client.createAuthorizationURLWithPKCE(
 				authorizationEndpoint,
 				state,
@@ -29,11 +31,9 @@ export class Discord {
 		return url;
 	}
 
-	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string | null
-	): Promise<OAuth2Tokens> {
-		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier || null);
 		return tokens;
 	}
 

--- a/src/providers/donation-alerts.ts
+++ b/src/providers/donation-alerts.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.donationalerts.com/oauth/authorize";
 const tokenEndpoint = "https://www.donationalerts.com/oauth/token";
 
-export class DonationAlerts {
+export class DonationAlerts implements OAuth2Provider<["scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class DonationAlerts {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "scopes">): URL {
+		const { scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -25,7 +27,8 @@ export class DonationAlerts {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/dribbble.ts
+++ b/src/providers/dribbble.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://dribbble.com/oauth/authorize";
 const tokenEndpoint = "https://dribbble.com/oauth/token";
 
-export class Dribbble {
+export class Dribbble implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Dribbble {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,9 +30,10 @@ export class Dribbble {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);

--- a/src/providers/dropbox.ts
+++ b/src/providers/dropbox.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,19 +7,21 @@ const authorizationEndpoint = "https://www.dropbox.com/oauth2/authorize";
 const tokenEndpoint = "https://api.dropboxapi.com/oauth2/token";
 const tokenRevocationEndpoint = "https://api.dropboxapi.com/2/auth/token/revoke";
 
-export class Dropbox {
+export class Dropbox implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/epicgames.ts
+++ b/src/providers/epicgames.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,19 +7,21 @@ const authorizationEndpoint = "https://www.epicgames.com/id/authorize";
 const tokenEndpoint = "https://api.epicgames.dev/epic/oauth/v2/token";
 const tokenRevocationEndpoint = "https://api.epicgames.dev/epic/oauth/v2/revoke";
 
-export class EpicGames {
+export class EpicGames implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/etsy.ts
+++ b/src/providers/etsy.ts
@@ -1,18 +1,20 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.etsy.com/oauth/connect";
 const tokenEndpoint = "https://api.etsy.com/v3/public/oauth/token";
 
-export class Etsy {
+export class Etsy implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, null, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -24,9 +26,9 @@ export class Etsy {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/facebook.ts
+++ b/src/providers/facebook.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.facebook.com/v16.0/dialog/oauth";
 const tokenEndpoint = "https://graph.facebook.com/v16.0/oauth/access_token";
 
-export class Facebook {
+export class Facebook implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Facebook {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,7 +30,8 @@ export class Facebook {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/figma.ts
+++ b/src/providers/figma.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,19 +7,21 @@ const authorizationEndpoint = "https://www.figma.com/oauth";
 const tokenEndpoint = "https://api.figma.com/v1/oauth/token";
 const refreshEndpoint = "https://api.figma.com/v1/oauth/refresh";
 
-export class Figma {
+export class Figma implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/gitea.ts
+++ b/src/providers/gitea.ts
@@ -1,9 +1,10 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
 import { joinURIAndPath } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Gitea {
+export class Gitea implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 
@@ -15,7 +16,8 @@ export class Gitea {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -27,9 +29,9 @@ export class Gitea {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -7,11 +7,12 @@ import {
 	UnexpectedResponseError
 } from "../request.js";
 import { OAuth2Tokens } from "../oauth2.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 const authorizationEndpoint = "https://github.com/login/oauth/authorize";
 const tokenEndpoint = "https://github.com/login/oauth/access_token";
 
-export class GitHub {
+export class GitHub implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string | null;
@@ -22,7 +23,8 @@ export class GitHub {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -36,7 +38,8 @@ export class GitHub {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -1,9 +1,10 @@
 import { OAuth2Client } from "../client.js";
 import { joinURIAndPath } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class GitLab {
+export class GitLab implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -17,12 +18,14 @@ export class GitLab {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(this.authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(this.tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,14 +7,15 @@ const authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
 const tokenEndpoint = "https://oauth2.googleapis.com/token";
 const tokenRevocationEndpoint = "https://oauth2.googleapis.com/revoke";
 
-export class Google {
+export class Google implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -24,10 +26,8 @@ export class Google {
 		return url;
 	}
 
-	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
-	): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/intuit.ts
+++ b/src/providers/intuit.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,19 +7,21 @@ const authorizationEndpoint = "https://appcenter.intuit.com/connect/oauth2";
 const tokenEndpoint = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
 const tokenRevocationEndpoint = "https://developer.API.intuit.com/v2/oauth2/tokens/revoke";
 
-export class Intuit {
+export class Intuit implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/kakao.ts
+++ b/src/providers/kakao.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://kauth.kakao.com/oauth/authorize";
 const tokenEndpoint = "https://kauth.kakao.com/oauth/token";
 
-export class Kakao {
+export class Kakao implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Kakao {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,7 +30,8 @@ export class Kakao {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/keycloak.ts
+++ b/src/providers/keycloak.ts
@@ -1,8 +1,9 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class KeyCloak {
+export class KeyCloak implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -21,7 +22,8 @@ export class KeyCloak {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -33,9 +35,9 @@ export class KeyCloak {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/kick.ts
+++ b/src/providers/kick.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
 import { createS256CodeChallenge, type OAuth2Tokens } from "../oauth2.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 const authorizationEndpoint = "https://id.kick.com/oauth/authorize";
 const tokenEndpoint = "https://id.kick.com/oauth/token";
 const tokenRevocationEndpoint = "https://id.kick.com/oauth/revoke";
 
-export class Kick {
+export class Kick implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Kick {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("response_type", "code");
@@ -32,9 +34,9 @@ export class Kick {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("code", code);
 		body.set("client_id", this.clientId);

--- a/src/providers/lichess.ts
+++ b/src/providers/lichess.ts
@@ -1,17 +1,19 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://lichess.org/oauth";
 const tokenEndpoint = "https://lichess.org/api/token";
 
-export class Lichess {
+export class Lichess implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, null, redirectURI);
 	}
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -23,9 +25,9 @@ export class Lichess {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -1,12 +1,13 @@
 import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://access.line.me/oauth2/v2.1/authorize";
 const tokenEndpoint = "https://api.line.me/oauth2/v2.1/token";
 
-export class Line {
+export class Line implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class Line {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -33,9 +35,9 @@ export class Line {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://linear.app/oauth/authorize";
 const tokenEndpoint = "https://api.linear.app/oauth/token";
 
-export class Linear {
+export class Linear implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Linear {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,7 +30,8 @@ export class Linear {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/linkedin.ts
+++ b/src/providers/linkedin.ts
@@ -1,12 +1,13 @@
 // LinkedIn doesn't seem to support HTTP Basic Auth
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.linkedin.com/oauth/v2/authorization";
 const tokenEndpoint = "https://www.linkedin.com/oauth/v2/accessToken";
 
-export class LinkedIn {
+export class LinkedIn implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class LinkedIn {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,7 +31,8 @@ export class LinkedIn {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/mastodon.ts
+++ b/src/providers/mastodon.ts
@@ -1,9 +1,10 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
 import { joinURIAndPath } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Mastodon {
+export class Mastodon implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -17,7 +18,8 @@ export class Mastodon {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -29,9 +31,9 @@ export class Mastodon {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/mercadolibre.ts
+++ b/src/providers/mercadolibre.ts
@@ -1,12 +1,13 @@
 import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://auth.mercadolibre.com/authorization";
 const tokenEndpoint = "https://api.mercadolibre.com/oauth/token";
 
-export class MercadoLibre {
+export class MercadoLibre implements OAuth2Provider<["state", "codeVerifier"], ["code", "codeVerifier"]> {
 	public clientId: string;
 
 	private clientSecret: string;
@@ -19,7 +20,8 @@ export class MercadoLibre {
 	}
 
 	// `scopes` not required since they are defined in the application settings
-	public createAuthorizationURL(state: string, codeVerifier: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier">): URL {
+		const { state, codeVerifier } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -32,9 +34,9 @@ export class MercadoLibre {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/mercadopago.ts
+++ b/src/providers/mercadopago.ts
@@ -1,12 +1,13 @@
 import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://auth.mercadopago.com/authorization";
 const tokenEndpoint = "https://api.mercadopago.com/oauth/token";
 
-export class MercadoPago {
+export class MercadoPago implements OAuth2Provider<["state", "codeVerifier"], ["code", "codeVerifier"]> {
 	public clientId: string;
 
 	private clientSecret: string;
@@ -19,7 +20,8 @@ export class MercadoPago {
 	}
 
 	// `scopes` not required since they are defined in the application settings
-	public createAuthorizationURL(state: string, codeVerifier: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier">): URL {
+		const { state, codeVerifier } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -32,9 +34,9 @@ export class MercadoPago {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/microsoft-entra-id.ts
+++ b/src/providers/microsoft-entra-id.ts
@@ -5,10 +5,11 @@ import {
 	joinURIAndPath,
 	sendTokenRequest
 } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class MicrosoftEntraId {
+export class MicrosoftEntraId implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private clientId: string;
@@ -31,7 +32,8 @@ export class MicrosoftEntraId {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = new URL(this.authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -47,9 +49,9 @@ export class MicrosoftEntraId {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/myanimelist.ts
+++ b/src/providers/myanimelist.ts
@@ -1,18 +1,20 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://myanimelist.net/v1/oauth2/authorize";
 const tokenEndpoint = "https://myanimelist.net/v1/oauth2/token";
 
-export class MyAnimeList {
+export class MyAnimeList implements OAuth2Provider<["state", "codeVerifier"], ["code", "codeVerifier"]> {
 	private client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string | null) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier">): URL {
+		const { state, codeVerifier } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -24,9 +26,9 @@ export class MyAnimeList {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/naver.ts
+++ b/src/providers/naver.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://nid.naver.com/oauth2.0/authorize";
 const tokenEndpoint = "https://nid.naver.com/oauth2.0/token";
 
-export class Naver {
+export class Naver implements OAuth2Provider<[], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,7 @@ export class Naver {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(): URL {
+	public createAuthorizationURL(options: {}): URL {
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -24,7 +25,8 @@ export class Naver {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("client_id", this.clientId);

--- a/src/providers/notion.ts
+++ b/src/providers/notion.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://api.notion.com/v1/oauth/authorize";
 const tokenEndpoint = "https://api.notion.com/v1/oauth/token";
 
-export class Notion {
+export class Notion implements OAuth2Provider<["state"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state">): URL {
+		const { state } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, []);
 		url.searchParams.set("owner", "user");
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/okta.ts
+++ b/src/providers/okta.ts
@@ -1,9 +1,10 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 import { joinURIAndPath } from "../request.js";
 
-export class Okta {
+export class Okta implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -27,7 +28,8 @@ export class Okta {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -39,9 +41,9 @@ export class Okta {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/osu.ts
+++ b/src/providers/osu.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://osu.ppy.sh/oauth/authorize";
 const tokenEndpoint = "https://osu.ppy.sh/oauth/token";
 
-export class Osu {
+export class Osu implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string | null;
@@ -16,7 +17,8 @@ export class Osu {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -30,9 +32,10 @@ export class Osu {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		if (this.redirectURI !== null) {
 			body.set("redirect_uri", this.redirectURI);
@@ -40,6 +43,7 @@ export class Osu {
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(tokenEndpoint, body);
+
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}

--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.patreon.com/oauth2/authorize";
 const tokenEndpoint = "https://www.patreon.com/api/oauth2/token";
 
-export class Patreon {
+export class Patreon implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Patreon {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,7 +30,8 @@ export class Patreon {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -1,5 +1,6 @@
 import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -8,7 +9,7 @@ const tokenEndpoint = "https://api.polar.sh/v1/oauth2/token";
 const tokenRevocationEndpoint = "https://api.polar.sh/v1/oauth2/revoke";
 
 // Polar.sh supports HTTP Basic Auth but `client_secret` is set as the default authentication method.
-export class Polar {
+export class Polar implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private clientId: string;
 	private clientSecret: string | null;
 	private redirectURI: string;
@@ -19,7 +20,8 @@ export class Polar {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("response_type", "code");
@@ -35,9 +37,9 @@ export class Polar {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("code", code);
 		body.set("client_id", this.clientId);

--- a/src/providers/reddit.ts
+++ b/src/providers/reddit.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.reddit.com/api/v1/authorize";
 const tokenEndpoint = "https://www.reddit.com/api/v1/access_token";
 
-export class Reddit {
+export class Reddit implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/roblox.ts
+++ b/src/providers/roblox.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,14 +7,15 @@ const authorizationEndpoint = "https://apis.roblox.com/oauth/v1/authorize";
 const tokenEndpoint = "https://apis.roblox.com/oauth/v1/token";
 const tokenRevocationEndpoint = "https://apis.roblox.com/oauth/v1/token/revoke";
 
-export class Roblox {
+export class Roblox implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -25,9 +27,9 @@ export class Roblox {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/salesforce.ts
+++ b/src/providers/salesforce.ts
@@ -1,8 +1,9 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Salesforce {
+export class Salesforce implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 	private tokenRevocationEndpoint: string;
@@ -16,7 +17,8 @@ export class Salesforce {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -28,9 +30,9 @@ export class Salesforce {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/shikimori.ts
+++ b/src/providers/shikimori.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://shikimori.one/oauth/authorize";
 const tokenEndpoint = "https://shikimori.one/oauth/token";
 
-export class Shikimori {
+export class Shikimori implements OAuth2Provider<["state"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Shikimori {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state">): URL {
+		const { state } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -25,14 +27,16 @@ export class Shikimori {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(tokenEndpoint, body);
+
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}

--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://slack.com/openid/connect/authorize";
 const tokenEndpoint = "https://slack.com/api/openid.connect.token";
 
-export class Slack {
+export class Slack implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string | null) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/spotify.ts
+++ b/src/providers/spotify.ts
@@ -1,20 +1,22 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://accounts.spotify.com/authorize";
 const tokenEndpoint = "https://accounts.spotify.com/api/token";
 
-export class Spotify {
+export class Spotify implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string | null, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		let url: URL;
-		if (codeVerifier !== null) {
+		if (codeVerifier) {
 			url = this.client.createAuthorizationURLWithPKCE(
 				authorizationEndpoint,
 				state,
@@ -29,10 +31,10 @@ export class Spotify {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string | null
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
-		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
+		const { code, codeVerifier } = options;
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier || null);
 		return tokens;
 	}
 

--- a/src/providers/startgg.ts
+++ b/src/providers/startgg.ts
@@ -1,4 +1,5 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,7 +7,7 @@ const authorizationEndpoint = "https://start.gg/oauth/authorize";
 const tokenEndpoint = "https://api.start.gg/oauth/access_token";
 const refreshEndpoint = "https://api.start.gg/oauth/refresh";
 
-export class StartGG {
+export class StartGG implements OAuth2Provider<["state", "scopes"], ["code", "scopes"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class StartGG {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,7 +31,8 @@ export class StartGG {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string, scopes: string[]): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code" | "scopes">): Promise<OAuth2Tokens> {
+		const { code, scopes = [] } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/strava.ts
+++ b/src/providers/strava.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.strava.com/oauth/authorize";
 const tokenEndpoint = "https://www.strava.com/api/v3/oauth/token";
 
-export class Strava {
+export class Strava implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Strava {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,7 +31,8 @@ export class Strava {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/synology.ts
+++ b/src/providers/synology.ts
@@ -1,9 +1,10 @@
 import { CodeChallengeMethod, OAuth2Client } from "../client.js";
 import { joinURIAndPath } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-export class Synology {
+export class Synology implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private authorizationEndpoint: string;
 	private tokenEndpoint: string;
 
@@ -21,7 +22,8 @@ export class Synology {
 		this.client = new OAuth2Client(applicationId, applicationSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			this.authorizationEndpoint,
 			state,
@@ -33,9 +35,9 @@ export class Synology {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(
 			this.tokenEndpoint,
 			code,

--- a/src/providers/tiktok.ts
+++ b/src/providers/tiktok.ts
@@ -1,5 +1,6 @@
 import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest, sendTokenRevocationRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -7,7 +8,7 @@ const authorizationEndpoint = "https://www.tiktok.com/v2/auth/authorize";
 const tokenEndpoint = "https://open.tiktokapis.com/v2/oauth/token/";
 const tokenRevocationEndpoint = "https://open.tiktokapis.com/v2/oauth/revoke/";
 
-export class TikTok {
+export class TikTok implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private clientKey: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -18,7 +19,8 @@ export class TikTok {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_key", this.clientKey);
@@ -34,9 +36,9 @@ export class TikTok {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/tiltify.ts
+++ b/src/providers/tiltify.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://v5api.tiltify.com/oauth/authorize";
 const tokenEndpoint = "https://v5api.tiltify.com/oauth/token";
 
-export class Tiltify {
+export class Tiltify implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class Tiltify {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,14 +30,16 @@ export class Tiltify {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(tokenEndpoint, body);
+
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}

--- a/src/providers/tumblr.ts
+++ b/src/providers/tumblr.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://www.tumblr.com/oauth2/authorize";
 const tokenEndpoint = "https://api.tumblr.com/v2/oauth2/token";
 
-export class Tumblr {
+export class Tumblr implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/twitch.ts
+++ b/src/providers/twitch.ts
@@ -1,12 +1,13 @@
 // Does not support HTTP Basic Auth scheme.
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://id.twitch.tv/oauth2/authorize";
 const tokenEndpoint = "https://id.twitch.tv/oauth2/token";
 
-export class Twitch {
+export class Twitch implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -17,7 +18,8 @@ export class Twitch {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -29,7 +31,8 @@ export class Twitch {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,14 +7,15 @@ const authorizationEndpoint = "https://twitter.com/i/oauth2/authorize";
 const tokenEndpoint = "https://api.twitter.com/2/oauth2/token";
 const tokenRevocationEndpoint = "https://api.twitter.com/2/oauth2/revoke";
 
-export class Twitter {
+export class Twitter implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -25,9 +27,9 @@ export class Twitter {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}

--- a/src/providers/vk.ts
+++ b/src/providers/vk.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://oauth.vk.com/authorize";
 const tokenEndpoint = "https://oauth.vk.com/access_token";
 
-export class VK {
+export class VK implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -16,7 +17,8 @@ export class VK {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -28,14 +30,16 @@ export class VK {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(tokenEndpoint, body);
+
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}

--- a/src/providers/withings.ts
+++ b/src/providers/withings.ts
@@ -6,11 +6,12 @@ import {
 	UnexpectedResponseError
 } from "../request.js";
 import { OAuth2Tokens } from "../oauth2.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 const authorizationEndpoint = "https://account.withings.com/oauth2_user/authorize2";
 const tokenEndpoint = "https://wbsapi.withings.net/v2/oauth2";
 
-export class Withings {
+export class Withings implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private clientId: string;
 	private clientSecret: string;
 	private redirectURI: string;
@@ -21,7 +22,8 @@ export class Withings {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
@@ -34,11 +36,12 @@ export class Withings {
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		// Withings requires an `action` parameter.
 		body.set("action", "requesttoken");
 		body.set("grant_type", "authorization_code");
+		const { code } = options;
 		body.set("code", code);
 		body.set("redirect_uri", this.redirectURI);
 		body.set("client_id", this.clientId);

--- a/src/providers/workos.ts
+++ b/src/providers/workos.ts
@@ -1,11 +1,12 @@
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import { createS256CodeChallenge, type OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://api.workos.com/sso/authorize";
 const tokenEndpoint = "https://api.workos.com/sso/token";
 
-export class WorkOS {
+export class WorkOS implements OAuth2Provider<["state", "codeVerifier"], ["code", "codeVerifier"]> {
 	private clientId: string;
 	private clientSecret: string | null;
 	private redirectURI: string;
@@ -16,13 +17,14 @@ export class WorkOS {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string | null): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier">): URL {
+		const { state, codeVerifier } = options;
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("state", state);
 		url.searchParams.set("redirect_uri", this.redirectURI);
-		if (codeVerifier !== null) {
+		if (codeVerifier) {
 			const codeChallenge = createS256CodeChallenge(codeVerifier);
 			url.searchParams.set("code_challenge_method", "S256");
 			url.searchParams.set("code_challenge", codeChallenge);
@@ -31,9 +33,9 @@ export class WorkOS {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string | null
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("code", code);
@@ -42,7 +44,7 @@ export class WorkOS {
 		if (this.clientSecret !== null) {
 			body.set("client_secret", this.clientSecret);
 		}
-		if (codeVerifier !== null) {
+		if (codeVerifier) {
 			body.set("code_verifier", codeVerifier);
 		}
 		const request = createOAuth2Request(tokenEndpoint, body);

--- a/src/providers/yahoo.ts
+++ b/src/providers/yahoo.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://api.login.yahoo.com/oauth2/request_auth";
 const tokenEndpoint = "https://api.login.yahoo.com/oauth2/get_token";
 
-export class Yahoo {
+export class Yahoo implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/yandex.ts
+++ b/src/providers/yandex.ts
@@ -1,23 +1,26 @@
 import { OAuth2Client } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
 const authorizationEndpoint = "https://oauth.yandex.com/authorize";
 const tokenEndpoint = "https://oauth.yandex.com/token";
 
-export class Yandex {
+export class Yandex implements OAuth2Provider<["state", "scopes"], ["code"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "scopes">): URL {
+		const { state, scopes = [] } = options;
 		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(options: Pick<OAuth2ValidationOptions, "code">): Promise<OAuth2Tokens> {
+		const { code } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
 		return tokens;
 	}

--- a/src/providers/zoom.ts
+++ b/src/providers/zoom.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+import type { OAuth2Provider, OAuth2AuthorizationOptions, OAuth2ValidationOptions } from "../provider.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
@@ -6,14 +7,15 @@ const authorizationEndpoint = "https://zoom.us/oauth/authorize";
 const tokenEndpoint = "https://zoom.us/oauth/token";
 const tokenRevocationEndpoint = "https://zoom.us/oauth/revoke";
 
-export class Zoom {
+export class Zoom implements OAuth2Provider<["state", "codeVerifier", "scopes"], ["code", "codeVerifier"]> {
 	private client: OAuth2Client;
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 
-	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+	public createAuthorizationURL(options: Pick<OAuth2AuthorizationOptions, "state" | "codeVerifier" | "scopes">): URL {
+		const { state, codeVerifier, scopes = [] } = options;
 		const url = this.client.createAuthorizationURLWithPKCE(
 			authorizationEndpoint,
 			state,
@@ -25,9 +27,9 @@ export class Zoom {
 	}
 
 	public async validateAuthorizationCode(
-		code: string,
-		codeVerifier: string
+		options: Pick<OAuth2ValidationOptions, "code" | "codeVerifier">
 	): Promise<OAuth2Tokens> {
+		const { code, codeVerifier } = options;
 		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
 		return tokens;
 	}


### PR DESCRIPTION
Closes https://github.com/pilcrowonpaper/arctic/issues/310

This is a breaking change as it switches from positional arguments to a single argument with property-based parameters.

The provider interface is quite simple and I don't expect it would need to be extended in the future. Luckily `arctic`'s design is quite nice where most of the per-provider custom logic is hidden away internally in the provider or requested through the constructor, so these common methods are quite standard. However, if the need ever arose, it could be extended to support some new provider field without a breaking change for the existing providers. If there were one that was really off the walls you could still implement a custom class without implementing the interface, but again I don't forsee that as ever being necessary.

If we wanted to avoid breaking existing users and make for an easier migration path we could leave the existing methods with positional arguments in place alongside the new methods and could simply have one call the other.

I put `OAuth2` in the class names, but am not 100% sure that's correct or if arctic could possibly be used with OAuth 1 as well, so am open to renaming those.

I didn't update the docs yet as I wanted feedback on this change before doing so, but would be happy to update the docs if you're amenable to this change.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
