### PR TITLE
Fix Slack user endpoint in documentation

### DIFF
--- a/docs/pages/providers/slack.md
+++ b/docs/pages/providers/slack.md
@@ -68,7 +68,7 @@ const claims = arctic.decodeIdToken(idToken);
 ```
 
 ```ts
-const response = await fetch("https://openidconnect.googleapis.com/v1/userinfo", {
+const response = await fetch("https://slack.com/api/openid.connect.userInfo", {
 	headers: {
 		Authorization: `Bearer ${accessToken}`
 	}


### PR DESCRIPTION
Fixes the slack user endpoint in documentation, as it was changed in commit 1fc623f to one of google's APIs, likely by accident.

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
