### PR TITLE
fix: new mastodon paths

### DIFF
--- a/.RELEASE.md
+++ b/.RELEASE.md
@@ -1,1 +1,0 @@
-- Add Withings provider ([#304](https://github.com/pilcrowonpaper/arctic/pull/304))

--- a/src/providers/mastodon.ts
+++ b/src/providers/mastodon.ts
@@ -11,9 +11,9 @@ export class Mastodon {
 	private client: OAuth2Client;
 
 	constructor(baseURL: string, clientId: string, clientSecret: string, redirectURI: string) {
-		this.authorizationEndpoint = joinURIAndPath(baseURL, "/api/v1/oauth/authorize");
-		this.tokenEndpoint = joinURIAndPath(baseURL, "/api/v1/oauth/token");
-		this.tokenRevocationEndpoint = joinURIAndPath(baseURL, "/api/v1/oauth/revoke");
+		this.authorizationEndpoint = joinURIAndPath(baseURL, 'oauth/authorize');
+    this.tokenEndpoint = joinURIAndPath(baseURL, '/oauth/token');
+    this.tokenRevocationEndpoint = joinURIAndPath(baseURL, '/oauth/revoke');
 		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
 	}
 


### PR DESCRIPTION
This fixes an issue with the Mastodon paths that means that it can't be used as a provider.

Either the paths here were always incorrect or have changed since the implementation.

Verified that these are the paths with the following:

- https://fosstodon.org/.well-known/oauth-authorization-server
- https://mastodon.social/.well-known/oauth-authorization-server

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
