### PR TITLE
feat: add Telegram provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Arctic does not strictly follow semantic versioning. While we aim to only introd
 - Start.gg
 - Strava
 - Synology
+- Telegram
 - TikTok
 - Tiltify
 - Tumblr

--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -70,6 +70,7 @@
 				["Start.gg", "/providers/startgg"],
 				["Strava", "/providers/strava"],
 				["Synology", "/providers/synology"],
+				["Telegram", "/providers/telegram"],
 				["TikTok", "/providers/tiktok"],
 				["Tiltify", "/providers/tiltify"],
 				["Tumblr", "/providers/tumblr"],

--- a/docs/pages/providers/telegram.md
+++ b/docs/pages/providers/telegram.md
@@ -1,0 +1,73 @@
+---
+title: "Telegram"
+---
+
+# Telegram
+
+OAuth 2.0 authorization code provider for Telegram.
+
+Also see [OAuth 2.0 with PKCE](/guides/oauth2-pkce).
+
+## Initialization
+
+```ts
+import * as arctic from "arctic";
+
+const telegram = new arctic.Telegram(clientId, clientSecret, redirectURI);
+```
+
+## Create authorization URL
+
+```ts
+import * as arctic from "arctic";
+
+const state = arctic.generateState();
+const codeVerifier = arctic.generateCodeVerifier();
+const scopes = ["openid", "profile"];
+const url = telegram.createAuthorizationURL(state, codeVerifier, scopes);
+```
+
+## Validate authorization code
+
+`validateAuthorizationCode()` will either return an [`OAuth2Tokens`](/reference/main/OAuth2Tokens), or throw one of [`OAuth2RequestError`](/reference/main/OAuth2RequestError), [`ArcticFetchError`](/reference/main/ArcticFetchError), [`UnexpectedResponseError`](/reference/main/UnexpectedResponseError), or [`UnexpectedErrorResponseBodyError`](/reference/main/UnexpectedErrorResponseBodyError). Telegram returns an access token with an expiration.
+
+```ts
+import * as arctic from "arctic";
+
+try {
+	const tokens = await telegram.validateAuthorizationCode(code, codeVerifier);
+	const accessToken = tokens.accessToken();
+	const accessTokenExpiresAt = tokens.accessTokenExpiresAt();
+} catch (e) {
+	if (e instanceof arctic.OAuth2RequestError) {
+		// Invalid authorization code, credentials, or redirect URI
+		const code = e.code;
+		// ...
+	}
+	if (e instanceof arctic.ArcticFetchError) {
+		// Failed to call `fetch()`
+		const cause = e.cause;
+		// ...
+	}
+	// Parse error
+}
+```
+
+## OpenID Connect
+
+Use OpenID Connect with the `openid` scope to get the user's profile from the ID token. Arctic provides [`decodeIdToken()`](/reference/main/decodeIdToken) for decoding the token's payload. Telegram does not provide a userinfo endpoint.
+
+Also see [ID token claims](https://core.telegram.org/bots/telegram-login#available-scopes).
+
+```ts
+const scopes = ["openid", "profile"];
+const url = telegram.createAuthorizationURL(state, codeVerifier, scopes);
+```
+
+```ts
+import * as arctic from "arctic";
+
+const tokens = await telegram.validateAuthorizationCode(code, codeVerifier);
+const idToken = tokens.idToken();
+const claims = arctic.decodeIdToken(idToken);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export { Spotify } from "./providers/spotify.js";
 export { StartGG } from "./providers/startgg.js";
 export { Strava } from "./providers/strava.js";
 export { Synology } from "./providers/synology.js";
+export { Telegram } from "./providers/telegram.js";
 export { TikTok } from "./providers/tiktok.js";
 export { Tiltify } from "./providers/tiltify.js";
 export { Tumblr } from "./providers/tumblr.js";

--- a/src/providers/telegram.ts
+++ b/src/providers/telegram.ts
@@ -1,0 +1,33 @@
+import { OAuth2Client, CodeChallengeMethod } from "../client.js";
+
+import type { OAuth2Tokens } from "../oauth2.js";
+
+const authorizationEndpoint = "https://oauth.telegram.org/auth";
+const tokenEndpoint = "https://oauth.telegram.org/token";
+
+export class Telegram {
+	private client: OAuth2Client;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string) {
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURLWithPKCE(
+			authorizationEndpoint,
+			state,
+			CodeChallengeMethod.S256,
+			codeVerifier,
+			scopes
+		);
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
+		return tokens;
+	}
+}


### PR DESCRIPTION
Telegram has released OAuth authentication and I've noticed it's missing here, so I decided to add it

Related issue: [#326](https://github.com/pilcrowonpaper/arctic/issues/326)

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
