### PR TITLE
fix: repeatedly getting asked to log in to X

### DIFF
--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -92,7 +92,7 @@
 			"pages": [
 				["v1 docs", "https://v1.arcticjs.dev"],
 				["GitHub", "https://github.com/pilcrowonpaper/arctic"],
-				["Twitter", "https://twitter.com/pilcrowonpaper"],
+				["Twitter", "https://x.com/pilcrowonpaper"],
 				["Donate", "https://github.com/sponsors/pilcrowOnPaper"]
 			]
 		}

--- a/docs/pages/providers/twitter.md
+++ b/docs/pages/providers/twitter.md
@@ -57,7 +57,7 @@ try {
 
 ## Get user profile
 
-Add the `users.read` and `tweet.read` scopes and use the [`/users/me` endpoint](https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me). You cannot get user emails with the v2 API.
+Add the `users.read` and `tweet.read` scopes and use the [`/users/me` endpoint](https://docs.x.com/x-api/users/get-my-user). You cannot get user emails with the v2 API.
 
 ```ts
 const scopes = ["users.read", "tweet.read"];
@@ -65,7 +65,7 @@ const url = twitter.createAuthorizationURL(state, codeVerifier, scopes);
 ```
 
 ```ts
-const response = await fetch("https://api.twitter.com/2/users/me", {
+const response = await fetch("https://api.x.com/2/users/me", {
 	headers: {
 		Authorization: `Bearer ${accessToken}`
 	}

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -2,9 +2,9 @@ import { OAuth2Client, CodeChallengeMethod } from "../client.js";
 
 import type { OAuth2Tokens } from "../oauth2.js";
 
-const authorizationEndpoint = "https://twitter.com/i/oauth2/authorize";
-const tokenEndpoint = "https://api.twitter.com/2/oauth2/token";
-const tokenRevocationEndpoint = "https://api.twitter.com/2/oauth2/revoke";
+const authorizationEndpoint = "https://x.com/i/oauth2/authorize";
+const tokenEndpoint = "https://api.x.com/2/oauth2/token";
+const tokenRevocationEndpoint = "https://api.x.com/2/oauth2/revoke";
 
 export class Twitter {
 	private client: OAuth2Client;


### PR DESCRIPTION
I observed a bug that twitter.com's log in flow stopped working. Repro steps

1. Clear cookies on x.com and twitter.com
2. Start the flow and open login page on twitter.com. It should say "To use this App you have to be logged in to X. [Log in]"
3. login with credentials
4. It shows again "To use this App you have to be logged in to X. [Log in]"

With switching to x.com, it doesn't happen.

- I also updated doc URL that doesn't work because they moved to under x.com.
- I also updated the domain of your X link

---

DO NOT DELETE THIS SECTION.

Thank you for creating a pull request!

If your pull request is just making changes to the docs, please create it against the `main` branch.

If your pull request is making changes to the library source code, please create it against the `next` branch. If your pull request adds a new feature to the library, please open a new issue first.

If you're unsure, you can just create it against the `main` branch.

- [x] Please tick this box if you’ve read and understood this section..
